### PR TITLE
Port to GTK4

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Using hardware acceleration is highly recommended. As stated in `GStreamer` wiki
 In the case of OpenGL based elements, the buffers have the GstVideoGLTextureUploadMeta meta, which
 efficiently copies the content of the VA-API surface into a GL texture.
 ```
-Clapper uses `OpenGL` based sinks, so when `VA-API` is available, both CPU and RAM usage is much lower.
+Clapper uses `OpenGL` based sinks, so when `VA-API` is available, both CPU and RAM usage is much lower. Especially if you have `gst-plugins-bad` 1.18+ with new `vah264dec` decoder which shares a single GL context with Clapper and uses DRM connection. If you have an AMD/Intel GPU, I highly recommend this new decoder.
 
-To use `VA-API` make sure you have `gstreamer1-vaapi` installed. Verify with:
+To use `VA-API` with H.264 videos, make sure you have `gst-plugins-bad` 1.18+. For other codecs additionally install `gstreamer1-vaapi`. Verify with:
 ```shell
+gst-inspect-1.0 vah264dec
 gst-inspect-1.0 vaapi
 ```
 On some older GPUs you might need to export `GST_VAAPI_ALL_DRIVERS=1` environment variable.
@@ -40,10 +41,12 @@ Other acceleration methods (supported by `GStreamer`) should also work, but I ha
 </details>
 
 ## Requirements
-Clapper uses `GStreamer` bindings from `GI` repository, so if your distro ships them as separate package, they must be installed first.
+Clapper uses GTK4 along with `GStreamer` bindings from `GI` repository, so if your distro ships them as separate package, they must be installed first.
 Additionally Clapper requires these `GStreamer` elements:
-* [gtkglsink](https://gstreamer.freedesktop.org/documentation/gtk/gtkglsink.html)
+* [gtk4glsink](https://gstreamer.freedesktop.org/documentation/gtk/gtkglsink.html)
 * [glsinkbin](https://gstreamer.freedesktop.org/documentation/opengl/glsinkbin.html)
+
+**Attention:** `gtk4glsink` is my own port of current GStreamer `gtkglsink` to GTK4. The element is not part of GStreamer yet (pending review). Fedora package is available in my OBS repository. It will be installed along with Clapper if you add my repo to `dnf` package manager. Otherwise you might want to build it yourself from [source code](https://gitlab.freedesktop.org/Rafostar/gst-plugins-good/-/tree/GTK4) of my gstreamer GTK4 branch.
 
 Other required plugins (codecs) depend on video format.
 
@@ -53,67 +56,88 @@ Recommended additional packages you should install manually via package manager:
 
 Please note that packages naming varies by distro.
 
-## Installation
+## Packages
+The [pkgs folder](https://github.com/Rafostar/clapper/tree/master/pkgs) in this repository contains build scripts for various package formats. You can use them to build package yourself or download one of pre-built packages:
+<details>
+  <summary><b>Debian, Fedora, openSUSE & Ubuntu</b></summary>
+  
+Pre-built packages are available in [my repo](https://software.opensuse.org//download.html?project=home%3ARafostar&package=clapper) ([see status](https://build.opensuse.org/package/show/home:Rafostar/clapper))
+</details>
+
+<details>
+<summary><b>Arch Linux</b></summary>
+
+You can get Clapper from the AUR: [clapper-git](https://aur.archlinux.org/packages/clapper-git), or
+```shell
+cd pkgs/arch
+makepkg -si
+```
+</details>
+
+## Installation from source code
 Run in terminal:
 ```shell
 meson builddir --prefix=/usr/local
 sudo meson install -C builddir
 ```
 
-Additional GStreamer elements installation:
+GStreamer elements installation:
 <details>
-  <summary>Fedora</summary>
+  <summary><b>Debian/Ubuntu</b></summary>
+
+```shell
+sudo apt install \
+  gstreamer1.0-plugins-base \
+  gstreamer1.0-plugins-good \
+  gstreamer1.0-plugins-bad \
+  gstreamer1.0-gl \
+  gstreamer1.0-gtk4 \
+  gstreamer1.0-libav \
+  gstreamer-vaapi
+```
+</details>
+
+<details>
+  <summary><b>Fedora</b></summary>
 
 Enable RPM Fusion and run:
 ```shell
 sudo dnf install \
   gstreamer1-plugins-base \
-  gstreamer1-plugins-good-gtk \
+  gstreamer1-plugins-good \
+  gstreamer1-plugins-good-gtk4 \
+  gstreamer1-plugins-bad-free \
+  gstreamer1-plugins-bad-free-extras \
   gstreamer1-libav \
   gstreamer1-vaapi
 ```
 </details>
 
 <details>
-  <summary>openSUSE</summary>
+  <summary><b>openSUSE</b></summary>
 
 ```shell
 sudo zypper install \
   gstreamer-plugins-base \
   gstreamer-plugins-good \
+  gstreamer-plugins-good-gtk4 \
+  gstreamer-plugins-bad \
   gstreamer-plugins-libav \
   gstreamer-plugins-vaapi
 ```
 </details>
 
 <details>
-  <summary>Arch Linux</summary>
+  <summary><b>Arch Linux</b></summary>
 
 ```shell
 sudo pacman -S \
   gst-plugins-base \
-  gst-plugin-gtk \
+  gst-plugins-good \
+  gst-plugin-gtk4 \
+  gst-plugins-bad-libs \
   gst-libav \
   gstreamer-vaapi
-```
-</details>
-
-## Packages
-The [pkgs folder](https://github.com/Rafostar/clapper/tree/master/pkgs) in this repository contains build scripts for various package formats. You can use them to build package yourself or download one of pre-built packages:
-<details>
-  <summary>Fedora, openSUSE & SLE (rpm)</summary>
-  
-Pre-built packages are available here:<br>
-[software.opensuse.org//download.html?project=home:sp1rit&package=clapper](https://software.opensuse.org//download.html?project=home%3Asp1rit&package=clapper) ([See status](https://build.opensuse.org/package/show/home:sp1rit/clapper))
-</details>
-
-<details>
-<summary>Arch Linux</summary>
-
-You can get clapper from the AUR: [clapper-git](https://aur.archlinux.org/packages/clapper-git), or
-```shell
-cd pkgs/arch
-makepkg -si
 ```
 </details>
 

--- a/clapper_src/app.js
+++ b/clapper_src/app.js
@@ -21,8 +21,6 @@ var App = GObject.registerClass({
 {
     _init(opts)
     {
-        GLib.set_prgname(APP_NAME);
-
         super._init({
             application_id: pkg.name
         });
@@ -204,27 +202,15 @@ var App = GObject.registerClass({
 
     _onWindowFullscreenChanged(window, isFullscreen)
     {
-        // when changing fullscreen pango layout of popup is lost
-        // and we need to re-add marks to the new layout
-        this.interface.controls.setVolumeMarks(false);
-
         if(isFullscreen) {
             this.setUpdateTimeInterval();
             this.setHideControlsTimeout();
-            this.interface.controls.unfullscreenButton.set_sensitive(true);
-            this.interface.controls.unfullscreenButton.show();
-            this.interface.showControls(true);
         }
         else {
             this.clearTimeout('updateTime');
-            this.interface.controls.unfullscreenButton.set_sensitive(false);
-            this.interface.controls.unfullscreenButton.hide();
-            this.interface.showControls(false);
         }
 
-        this.interface.setControlsOnVideo(isFullscreen);
-        this.interface.controls.setVolumeMarks(true);
-        this.interface.controls.setFullscreenMode(isFullscreen);
+        this.interface.setFullscreenMode(isFullscreen);
     }
 
     _onWindowKeyPressEvent(self, event)

--- a/clapper_src/app.js
+++ b/clapper_src/app.js
@@ -163,13 +163,7 @@ var App = GObject.registerClass({
 
         this.player.widget.width_request = 960;
         this.player.widget.height_request = 540;
-/*
-        this.player.widget.add_events(
-            Gdk.EventMask.SCROLL_MASK
-            | Gdk.EventMask.ENTER_NOTIFY_MASK
-            | Gdk.EventMask.LEAVE_NOTIFY_MASK
-        );
-*/
+
         this.interface.addPlayer(this.player);
         this.player.connect('state-changed', this._onPlayerStateChanged.bind(this));
 

--- a/clapper_src/app.js
+++ b/clapper_src/app.js
@@ -294,7 +294,7 @@ var App = GObject.registerClass({
             isInhibited = (this.inhibitCookie > 0);
         }
         else {
-            if(!this.inhibitCookie)
+            //if(!this.inhibitCookie)
                 return;
 
             /* Uninhibit seems to be broken as of GTK 3.99.2

--- a/clapper_src/app.js
+++ b/clapper_src/app.js
@@ -117,7 +117,7 @@ var App = GObject.registerClass({
         this.hideControlsTimeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 3, () => {
             this.hideControlsTimeout = null;
 
-            if(this.window.isFullscreen && this.isCursorInPlayer) {
+            if(this.window.isFullscreen && this.player.motionController.is_pointer) {
                 this.clearTimeout('updateTime');
                 this.interface.revealControls(false);
             }
@@ -176,16 +176,14 @@ var App = GObject.registerClass({
         this.player.clickGesture.connect(
             'pressed', this._onPlayerPressed.bind(this)
         );
-/*
-        this.player.connectWidget(
-            'enter-notify-event', this._onPlayerEnterNotifyEvent.bind(this)
-        );
-        this.player.connectWidget(
-            'leave-notify-event', this._onPlayerLeaveNotifyEvent.bind(this)
-        );
-*/
         this.player.keyController.connect(
             'key-pressed', this._onPlayerKeyPressed.bind(this)
+        );
+        this.player.motionController.connect(
+            'enter', this._onPlayerEnter.bind(this)
+        );
+        this.player.motionController.connect(
+            'leave', this._onPlayerLeave.bind(this)
         );
         this.player.motionController.connect(
             'motion', this._onPlayerMotion.bind(this)
@@ -327,19 +325,15 @@ var App = GObject.registerClass({
         }
     }
 
-    _onPlayerEnterNotifyEvent(self, event)
+    _onPlayerEnter(controller, x, y)
     {
-        this.isCursorInPlayer = true;
-
         this.setHideCursorTimeout();
         if(this.window.isFullscreen)
             this.setHideControlsTimeout();
     }
 
-    _onPlayerLeaveNotifyEvent(self, event)
+    _onPlayerLeave(controller)
     {
-        this.isCursorInPlayer = false;
-
         this.clearTimeout('hideCursor');
         this.clearTimeout('hideControls');
     }

--- a/clapper_src/app.js
+++ b/clapper_src/app.js
@@ -84,7 +84,7 @@ var App = GObject.registerClass({
     {
         super.vfunc_activate();
 
-        this.window.show();
+        this.window.present();
         Gtk.StyleContext.add_provider_for_display(
             Gdk.Display.get_default(),
             this.cssProvider,
@@ -307,8 +307,10 @@ var App = GObject.registerClass({
             if(!this.inhibitCookie)
                 return;
 
+            /* Uninhibit seems to be broken as of GTK 3.99.2
             this.uninhibit(this.inhibitCookie);
             this.inhibitCookie = null;
+            */
         }
 
         debug(`set prevent suspend to: ${isInhibited}`);

--- a/clapper_src/app.js
+++ b/clapper_src/app.js
@@ -164,6 +164,9 @@ var App = GObject.registerClass({
 
         if(!this.player.widget)
             return this.quit();
+
+        this.player.widget.width_request = 960;
+        this.player.widget.height_request = 540;
 /*
         this.player.widget.add_events(
             Gdk.EventMask.SCROLL_MASK

--- a/clapper_src/buttons.js
+++ b/clapper_src/buttons.js
@@ -12,7 +12,6 @@ class ClapperCustomButton extends Gtk.Button
             margin_bottom: 4,
             margin_start: 1,
             margin_end: 1,
-            can_focus: false,
         };
         Object.assign(opts, defaults);
 
@@ -111,6 +110,9 @@ class ClapperPopoverButton extends IconButton
         if(this.isFullscreen)
             this.popover.add_css_class('osd');
 
+        this.changeStateSignal = this.popover.connect('closed', () =>
+            this.unset_state_flags(Gtk.StateFlags.CHECKED)
+        );
         this.destroySignal = this.connect('destroy', this._onDestroy.bind(this));
     }
 
@@ -133,6 +135,7 @@ class ClapperPopoverButton extends IconButton
 
     vfunc_clicked()
     {
+        this.set_state_flags(Gtk.StateFlags.CHECKED, false);
         this.popover.popup();
     }
 
@@ -140,6 +143,7 @@ class ClapperPopoverButton extends IconButton
     {
         this.disconnect(this.destroySignal);
 
+        this.popover.disconnect(this.changeStateSignal);
         this.popover.unparent();
         this.popoverBox.emit('destroy');
         this.popover.emit('destroy');

--- a/clapper_src/buttons.js
+++ b/clapper_src/buttons.js
@@ -9,26 +9,26 @@ class BoxedIconButton extends Gtk.Button
             margin_top: 4,
             margin_bottom: 4,
             can_focus: false,
-            can_default: false,
+            //can_default: false,
         });
 
         this.isFullscreen = isFullscreen || false;
 
         size = size || Gtk.IconSize.SMALL_TOOLBAR;
-        let image = Gtk.Image.new_from_icon_name(icon, size);
+        let image = Gtk.Image.new_from_icon_name(icon);
 
-        if(image)
-            this.set_image(image);
-
+        //if(image)
+            //this.set_image(image);
+/*
         this.image.defaultSize = size;
         this.image.fullscreenSize = (size === Gtk.IconSize.SMALL_TOOLBAR)
             ? Gtk.IconSize.LARGE_TOOLBAR
             : Gtk.IconSize.DND;
-
-        this.get_style_context().add_class('flat');
+*/
+        this.add_css_class('flat');
 
         this.box = new Gtk.Box();
-        this.box.pack_start(this, false, false, 0);
+        this.box.append(this);
 
         super.show();
     }
@@ -49,12 +49,12 @@ class BoxedIconButton extends Gtk.Button
 
         this.isFullscreen = isFullscreen;
     }
-
+/*
     show_all()
     {
         this.box.show_all();
     }
-
+*/
     show()
     {
         this.box.show();
@@ -74,16 +74,16 @@ class BoxedPopoverButton extends BoxedIconButton
         super._init(icon, size, isFullscreen);
 
         this.popover = new Gtk.Popover({
-            relative_to: this.box
+            default_widget: this.box
         });
         this.popoverBox = new Gtk.Box({
             orientation: Gtk.Orientation.VERTICAL
         });
-        this.popover.add(this.popoverBox);
+        this.popover.set_child(this.popoverBox);
         this.popoverBox.show();
 
         if(this.isFullscreen)
-            this.popover.get_style_context().add_class('osd');
+            this.popover.add_css_class('osd');
     }
 
     setFullscreenMode(isEnabled)
@@ -91,8 +91,8 @@ class BoxedPopoverButton extends BoxedIconButton
         if(this.isFullscreen === isEnabled)
             return;
 
-        let action = (isEnabled) ? 'add_class' : 'remove_class';
-        this.popover.get_style_context()[action]('osd');
+        let action = (isEnabled) ? 'add' : 'remove';
+        this.popover[action + '_css_class']('osd');
 
         super.setFullscreenMode(isEnabled);
     }

--- a/clapper_src/buttons.js
+++ b/clapper_src/buttons.js
@@ -1,41 +1,51 @@
 const { GObject, Gtk } = imports.gi;
 
-var BoxedIconButton = GObject.registerClass(
-class BoxedIconButton extends Gtk.Button
+var IconButton = GObject.registerClass(
+class ClapperIconButton extends Gtk.Button
 {
-    _init(icon, size, isFullscreen)
+    _init(icon)
     {
         super._init({
             margin_top: 4,
             margin_bottom: 4,
+            margin_start: 1,
+            margin_end: 1,
             can_focus: false,
-            //can_default: false,
+            icon_name: icon,
         });
 
-        this.isFullscreen = isFullscreen || false;
-
-        size = size || Gtk.IconSize.SMALL_TOOLBAR;
-        let image = Gtk.Image.new_from_icon_name(icon);
-
-        //if(image)
-            //this.set_image(image);
-/*
-        this.image.defaultSize = size;
-        this.image.fullscreenSize = (size === Gtk.IconSize.SMALL_TOOLBAR)
-            ? Gtk.IconSize.LARGE_TOOLBAR
-            : Gtk.IconSize.DND;
-*/
+        this.isFullscreen = false;
         this.add_css_class('flat');
-
-        this.box = new Gtk.Box();
-        this.box.append(this);
-
-        super.show();
     }
 
-    get visible()
+    setFullscreenMode(isFullscreen)
     {
-        return this.box.visible;
+        this.isFullscreen = isFullscreen;
+    }
+});
+
+var PopoverButton = GObject.registerClass(
+class ClapperPopoverButton extends IconButton
+{
+    _init(icon)
+    {
+        super._init(icon);
+
+        this.popover = new Gtk.Popover({
+            position: Gtk.PositionType.TOP,
+        });
+        this.popoverBox = new Gtk.Box({
+            orientation: Gtk.Orientation.VERTICAL,
+        });
+
+        this.popover.set_parent(this);
+        this.popover.set_child(this.popoverBox);
+        this.popover.set_offset(0, -this.margin_top);
+
+        if(this.isFullscreen)
+            this.popover.add_css_class('osd');
+
+        this.destroySignal = this.connect('destroy', this._onDestroy.bind(this));
     }
 
     setFullscreenMode(isFullscreen)
@@ -43,62 +53,30 @@ class BoxedIconButton extends Gtk.Button
         if(this.isFullscreen === isFullscreen)
             return;
 
-        this.image.icon_size = (isFullscreen)
-            ? this.image.fullscreenSize
-            : this.image.defaultSize;
+        this.margin_top = (isFullscreen) ? 6 : 4;
+        this.popover.set_offset(0, -this.margin_top);
 
-        this.isFullscreen = isFullscreen;
-    }
-/*
-    show_all()
-    {
-        this.box.show_all();
-    }
-*/
-    show()
-    {
-        this.box.show();
-    }
-
-    hide()
-    {
-        this.box.hide();
-    }
-});
-
-var BoxedPopoverButton = GObject.registerClass(
-class BoxedPopoverButton extends BoxedIconButton
-{
-    _init(icon, size, isFullscreen)
-    {
-        super._init(icon, size, isFullscreen);
-
-        this.popover = new Gtk.Popover({
-            default_widget: this.box
-        });
-        this.popoverBox = new Gtk.Box({
-            orientation: Gtk.Orientation.VERTICAL
-        });
-        this.popover.set_child(this.popoverBox);
-        this.popoverBox.show();
-
-        if(this.isFullscreen)
-            this.popover.add_css_class('osd');
-    }
-
-    setFullscreenMode(isEnabled)
-    {
-        if(this.isFullscreen === isEnabled)
+        let cssClass = 'osd';
+        if(isFullscreen == this.popover.has_css_class(cssClass))
             return;
 
-        let action = (isEnabled) ? 'add' : 'remove';
-        this.popover[action + '_css_class']('osd');
+        let action = (isFullscreen) ? 'add' : 'remove';
+        this.popover[action + '_css_class'](cssClass);
 
-        super.setFullscreenMode(isEnabled);
+        super.setFullscreenMode(isFullscreen);
     }
 
     vfunc_clicked()
     {
         this.popover.popup();
+    }
+
+    _onDestroy()
+    {
+        this.disconnect(this.destroySignal);
+
+        this.popover.unparent();
+        this.popoverBox.emit('destroy');
+        this.popover.emit('destroy');
     }
 });

--- a/clapper_src/buttons.js
+++ b/clapper_src/buttons.js
@@ -65,6 +65,31 @@ class ClapperIconToggleButton extends IconButton
     }
 });
 
+var LabelButton = GObject.registerClass(
+class ClapperLabelButton extends CustomButton
+{
+    _init(text)
+    {
+        super._init({
+            margin_start: 0,
+            margin_end: 0,
+        });
+
+        this.customLabel = new Gtk.Label({
+            label: text,
+            single_line_mode: true,
+        });
+
+        this.customLabel.add_css_class('labelbutton');
+        this.set_child(this.customLabel);
+    }
+
+    set_label(text)
+    {
+        this.customLabel.set_text(text);
+    }
+});
+
 var PopoverButton = GObject.registerClass(
 class ClapperPopoverButton extends IconButton
 {

--- a/clapper_src/buttons.js
+++ b/clapper_src/buttons.js
@@ -1,18 +1,22 @@
 const { GObject, Gtk } = imports.gi;
 
-var IconButton = GObject.registerClass(
-class ClapperIconButton extends Gtk.Button
+var CustomButton = GObject.registerClass(
+class ClapperCustomButton extends Gtk.Button
 {
-    _init(icon)
+    _init(opts)
     {
-        super._init({
+        opts = opts || {};
+
+        let defaults = {
             margin_top: 4,
             margin_bottom: 4,
             margin_start: 1,
             margin_end: 1,
             can_focus: false,
-            icon_name: icon,
-        });
+        };
+        Object.assign(opts, defaults);
+
+        super._init(opts);
 
         this.isFullscreen = false;
         this.add_css_class('flat');
@@ -20,7 +24,44 @@ class ClapperIconButton extends Gtk.Button
 
     setFullscreenMode(isFullscreen)
     {
+        if(this.isFullscreen === isFullscreen)
+            return;
+
+        this.margin_top = (isFullscreen) ? 6 : 4;
         this.isFullscreen = isFullscreen;
+    }
+});
+
+var IconButton = GObject.registerClass(
+class ClapperIconButton extends CustomButton
+{
+    _init(icon)
+    {
+        super._init({
+            icon_name: icon,
+        });
+    }
+});
+
+var IconToggleButton = GObject.registerClass(
+class ClapperIconToggleButton extends IconButton
+{
+    _init(primaryIcon, secondaryIcon)
+    {
+        super._init(primaryIcon);
+
+        this.primaryIcon = primaryIcon;
+        this.secondaryIcon = secondaryIcon;
+    }
+
+    setPrimaryIcon()
+    {
+        this.icon_name = this.primaryIcon;
+    }
+
+    setSecondaryIcon()
+    {
+        this.icon_name = this.secondaryIcon;
     }
 });
 
@@ -53,7 +94,8 @@ class ClapperPopoverButton extends IconButton
         if(this.isFullscreen === isFullscreen)
             return;
 
-        this.margin_top = (isFullscreen) ? 6 : 4;
+        super.setFullscreenMode(isFullscreen);
+
         this.popover.set_offset(0, -this.margin_top);
 
         let cssClass = 'osd';
@@ -62,8 +104,6 @@ class ClapperPopoverButton extends IconButton
 
         let action = (isFullscreen) ? 'add' : 'remove';
         this.popover[action + '_css_class'](cssClass);
-
-        super.setFullscreenMode(isFullscreen);
     }
 
     vfunc_clicked()

--- a/clapper_src/controls.js
+++ b/clapper_src/controls.js
@@ -188,6 +188,7 @@ var Controls = GObject.registerClass({
             'media-playback-start-symbolic',
             'media-playback-pause-symbolic'
         );
+        this.togglePlayButton.add_css_class('playbackicon');
         this.addButton(this.togglePlayButton);
     }
 

--- a/clapper_src/controls.js
+++ b/clapper_src/controls.js
@@ -63,6 +63,8 @@ var Controls = GObject.registerClass({
         this.setDefaultWidgetBehaviour(this.openMenuButton);
         //this.forall(this.setDefaultWidgetBehaviour);
 
+        this.add_css_class('playercontrols');
+
         this.realizeSignal = this.connect('realize', this._onRealize.bind(this));
         this.destroySignal = this.connect('destroy', this._onDestroy.bind(this));
     }
@@ -75,9 +77,12 @@ var Controls = GObject.registerClass({
         this.unfullscreenButton.set_visible(isFullscreen);
     }
 
-    addButton(iconName)
+    addButton(buttonIcon)
     {
-        let button = new Buttons.IconButton(iconName);
+        let button = (buttonIcon instanceof Gtk.Button)
+            ? buttonIcon
+            : new Buttons.IconButton(buttonIcon);
+
         this.append(button);
         this.buttonsArr.push(button);
 
@@ -87,10 +92,8 @@ var Controls = GObject.registerClass({
     addPopoverButton(iconName)
     {
         let button = new Buttons.PopoverButton(iconName);
-        this.append(button);
-        this.buttonsArr.push(button);
 
-        return button;
+        return this.addButton(button);
     }
 
     addCheckButtons(box, array, activeId)
@@ -172,28 +175,11 @@ var Controls = GObject.registerClass({
 
     _addTogglePlayButton()
     {
-        this.togglePlayButton = this.addButton(
+        this.togglePlayButton = new Buttons.IconToggleButton(
             'media-playback-start-symbolic',
-            Gtk.IconSize.LARGE_TOOLBAR
+            'media-playback-pause-symbolic'
         );
-        this.togglePlayButton.setPlayImage = () =>
-        {
-/*
-            this.togglePlayButton.image.set_from_icon_name(
-                'media-playback-start-symbolic',
-                this.togglePlayButton.image.icon_size
-            );
-*/
-        }
-        this.togglePlayButton.setPauseImage = () =>
-        {
-/*
-            this.togglePlayButton.image.set_from_icon_name(
-                'media-playback-pause-symbolic',
-                this.togglePlayButton.image.icon_size
-            );
-*/
-        }
+        this.addButton(this.togglePlayButton);
     }
 
     _addPositionScale()
@@ -203,7 +189,16 @@ var Controls = GObject.registerClass({
             value_pos: Gtk.PositionType.LEFT,
             draw_value: true,
             hexpand: true,
+            valign: Gtk.Align.CENTER,
         });
+
+        this.togglePlayButton.bind_property('margin_top',
+            this.positionScale, 'margin_top', GObject.BindingFlags.SYNC_CREATE
+        );
+        this.togglePlayButton.bind_property('margin_bottom',
+            this.positionScale, 'margin_bottom', GObject.BindingFlags.SYNC_CREATE
+        );
+
         this.positionScale.add_css_class('positionscale');
         this.positionScale.set_format_value_func(
             this._onPositionScaleFormatValue.bind(this)

--- a/clapper_src/controls.js
+++ b/clapper_src/controls.js
@@ -57,19 +57,18 @@ var Controls = GObject.registerClass({
         );
         this.fullscreenButton = Gtk.Button.new_from_icon_name(
             'view-fullscreen-symbolic',
-            Gtk.IconSize.SMALL_TOOLBAR
+            //Gtk.IconSize.SMALL_TOOLBAR
         );
         this.setDefaultWidgetBehaviour(this.fullscreenButton);
         this.openMenuButton = Gtk.Button.new_from_icon_name(
             'open-menu-symbolic',
-            Gtk.IconSize.SMALL_TOOLBAR
+            //Gtk.IconSize.SMALL_TOOLBAR
         );
         this.setDefaultWidgetBehaviour(this.openMenuButton);
-        this.forall(this.setDefaultWidgetBehaviour);
+        //this.forall(this.setDefaultWidgetBehaviour);
 
-        this.realizeSignal = this.connect(
-            'realize', this._onControlsRealize.bind(this)
-        );
+        this.realizeSignal = this.connect('realize', this._onControlsRealize.bind(this));
+        this.destroySignal = this.connect('destroy', this._onControlsDestroy.bind(this));
     }
 
     pack_start(widget, expand, fill, padding)
@@ -81,7 +80,7 @@ var Controls = GObject.registerClass({
         )
             widget = widget.box;
 
-        super.pack_start(widget, expand, fill, padding);
+        super.append(widget);
     }
 
     setFullscreenMode(isFullscreen)
@@ -121,6 +120,8 @@ var Controls = GObject.registerClass({
 
     addRadioButtons(box, array, activeId)
     {
+        return;
+
         let group = null;
         let children = box.get_children();
         let lastEl = (children.length > array.length)
@@ -175,7 +176,7 @@ var Controls = GObject.registerClass({
     setDefaultWidgetBehaviour(widget)
     {
         widget.can_focus = false;
-        widget.can_default = false;
+        //widget.can_default = false;
     }
 
     setVolumeMarks(isAdded)
@@ -212,17 +213,21 @@ var Controls = GObject.registerClass({
         );
         this.togglePlayButton.setPlayImage = () =>
         {
+/*
             this.togglePlayButton.image.set_from_icon_name(
                 'media-playback-start-symbolic',
                 this.togglePlayButton.image.icon_size
             );
+*/
         }
         this.togglePlayButton.setPauseImage = () =>
         {
+/*
             this.togglePlayButton.image.set_from_icon_name(
                 'media-playback-pause-symbolic',
                 this.togglePlayButton.image.icon_size
             );
+*/
         }
     }
 
@@ -234,19 +239,18 @@ var Controls = GObject.registerClass({
             draw_value: true,
             hexpand: true,
         });
-        let style = this.positionScale.get_style_context();
-        style.add_class('positionscale');
-
-        this.positionScale.connect(
-            'format-value', this._onPositionScaleFormatValue.bind(this)
+        this.positionScale.add_css_class('positionscale');
+        this.positionScale.set_format_value_func(
+            this._onPositionScaleFormatValue.bind(this)
         );
+/*
         this.positionScale.connect(
             'button-press-event', this._onPositionScaleButtonPressEvent.bind(this)
         );
         this.positionScale.connect(
             'button-release-event', this._onPositionScaleButtonReleaseEvent.bind(this)
         );
-
+*/
         this.positionAdjustment = this.positionScale.get_adjustment();
         this.pack_start(this.positionScale, true, true, 0);
     }
@@ -256,10 +260,10 @@ var Controls = GObject.registerClass({
         this.volumeButton = this.addPopoverButton(
             'audio-volume-muted-symbolic'
         );
-        this.volumeButton.add_events(Gdk.EventMask.SCROLL_MASK);
-        this.volumeButton.connect(
-            'scroll-event', (self, event) => this._onScrollEvent(event)
-        );
+        //this.volumeButton.add_events(Gdk.EventMask.SCROLL_MASK);
+        //this.volumeButton.connect(
+        //    'scroll-event', (self, event) => this._onScrollEvent(event)
+        //);
         this.volumeScale = new Gtk.Scale({
             orientation: Gtk.Orientation.VERTICAL,
             inverted: true,
@@ -268,7 +272,7 @@ var Controls = GObject.registerClass({
             round_digits: 2,
             vexpand: true,
         });
-        this.volumeScale.get_style_context().add_class('volumescale');
+        this.volumeScale.add_css_class('volumescale');
         this.volumeAdjustment = this.volumeScale.get_adjustment();
 
         this.volumeAdjustment.set_upper(2);
@@ -276,8 +280,8 @@ var Controls = GObject.registerClass({
         this.volumeAdjustment.set_page_increment(0.05);
         this.setDefaultWidgetBehaviour(this.volumeScale);
 
-        this.volumeButton.popoverBox.add(this.volumeScale);
-        this.volumeButton.popoverBox.show_all();
+        this.volumeButton.popoverBox.append(this.volumeScale);
+        //this.volumeButton.popoverBox.show_all();
 
         this.setVolumeMarks(true);
     }
@@ -374,5 +378,11 @@ var Controls = GObject.registerClass({
             default:
                 break;
         }
+    }
+
+    _onControlsDestroy()
+    {
+        this.disconnect(this.destroySignal);
+        this.positionScale.set_format_value_func(null);
     }
 });

--- a/clapper_src/controls.js
+++ b/clapper_src/controls.js
@@ -57,12 +57,9 @@ var Controls = GObject.registerClass({
         this.fullscreenButton = Gtk.Button.new_from_icon_name(
             'view-fullscreen-symbolic',
         );
-        this.setDefaultWidgetBehaviour(this.fullscreenButton);
         this.openMenuButton = Gtk.Button.new_from_icon_name(
             'open-menu-symbolic',
         );
-        this.setDefaultWidgetBehaviour(this.openMenuButton);
-        //this.forall(this.setDefaultWidgetBehaviour);
 
         this.add_css_class('playercontrols');
 
@@ -136,7 +133,6 @@ var Controls = GObject.registerClass({
                     'toggled',
                     this._onCheckButtonToggled.bind(this, checkButton)
                 );
-                this.setDefaultWidgetBehaviour(checkButton);
                 box.append(checkButton);
             }
 
@@ -158,12 +154,6 @@ var Controls = GObject.registerClass({
             if(child)
                 child = child.get_next_sibling();
         }
-    }
-
-    setDefaultWidgetBehaviour(widget)
-    {
-        widget.can_focus = false;
-        //widget.can_default = false;
     }
 
     handleScaleIncrement(type, isUp)
@@ -201,6 +191,7 @@ var Controls = GObject.registerClass({
             draw_value: false,
             hexpand: true,
             valign: Gtk.Align.CENTER,
+            can_focus: false,
         });
 
         this.togglePlayButton.bind_property('margin_top',
@@ -247,7 +238,6 @@ var Controls = GObject.registerClass({
         this.volumeAdjustment.set_upper(2);
         this.volumeAdjustment.set_step_increment(0.05);
         this.volumeAdjustment.set_page_increment(0.05);
-        this.setDefaultWidgetBehaviour(this.volumeScale);
 
         for(let i = 0; i <= 2; i++) {
             let text = (i) ? `${i}00%` : '0%';

--- a/clapper_src/controls.js
+++ b/clapper_src/controls.js
@@ -203,14 +203,14 @@ var Controls = GObject.registerClass({
 
         this.positionScale.add_css_class('positionscale');
         this.positionScale.connect('value-changed', this._onPositionScaleValueChanged.bind(this));
-/*
+
+        /* GTK4 is missing pressed/released signals for GtkRange/GtkScale.
+         * We cannot add controllers, cause it already has them, so we
+         * workaround this by observing css classes it currently has */
         this.positionScale.connect(
-            'button-press-event', this._onPositionScaleButtonPressEvent.bind(this)
+            'notify::css-classes', this._onPositionScaleDragging.bind(this)
         );
-        this.positionScale.connect(
-            'button-release-event', this._onPositionScaleButtonReleaseEvent.bind(this)
-        );
-*/
+
         this.positionAdjustment = this.positionScale.get_adjustment();
         this.append(this.positionScale);
     }
@@ -295,15 +295,14 @@ var Controls = GObject.registerClass({
         this.elapsedButton.set_label(elapsed);
     }
 
-    _onPositionScaleButtonPressEvent()
+    _onPositionScaleDragging(scale)
     {
-        this.isPositionSeeking = true;
-        this.emit('position-seeking-changed', this.isPositionSeeking);
-    }
+        let isPositionSeeking = scale.has_css_class('dragging');
 
-    _onPositionScaleButtonReleaseEvent()
-    {
-        this.isPositionSeeking = false;
+        if(this.isPositionSeeking === isPositionSeeking)
+            return;
+
+        this.isPositionSeeking = isPositionSeeking;
         this.emit('position-seeking-changed', this.isPositionSeeking);
     }
 

--- a/clapper_src/headerbar.js
+++ b/clapper_src/headerbar.js
@@ -5,7 +5,9 @@ class ClapperHeaderBar extends Gtk.HeaderBar
 {
     _init(window, startButtons, endButtons)
     {
-        super._init();
+        super._init({
+            can_focus: false,
+        });
 
         this.set_title_widget(this._createWidgetForWindow(window));
         startButtons.forEach(btn => this.pack_start(btn));
@@ -43,7 +45,7 @@ class ClapperHeaderBar extends Gtk.HeaderBar
     {
         let box = new Gtk.Box ({
             orientation: Gtk.Orientation.VERTICAL,
-            valign: Gtk.Align.CENTER
+            valign: Gtk.Align.CENTER,
         });
 
         this.titleLabel = new Gtk.Label({

--- a/clapper_src/headerbar.js
+++ b/clapper_src/headerbar.js
@@ -1,0 +1,73 @@
+const { GLib, GObject, Gtk, Pango } = imports.gi;
+
+var HeaderBar = GObject.registerClass(
+class ClapperHeaderBar extends Gtk.HeaderBar
+{
+    _init(window, startButtons, endButtons)
+    {
+        super._init();
+
+        this.set_title_widget(this._createWidgetForWindow(window));
+        startButtons.forEach(btn => this.pack_start(btn));
+        endButtons.forEach(btn => this.pack_end(btn));
+    }
+
+    updateHeaderBar(mediaInfo)
+    {
+        let title = mediaInfo.get_title();
+        let subtitle = mediaInfo.get_uri() || null;
+
+        if(subtitle && subtitle.startsWith('file://')) {
+            subtitle = GLib.filename_from_uri(subtitle)[0];
+            subtitle = GLib.path_get_basename(subtitle);
+        }
+
+        if(!title) {
+            title = (!subtitle)
+                ? this.defaultTitle
+                : (subtitle.includes('.'))
+                ? subtitle.split('.').slice(0, -1).join('.')
+                : subtitle;
+
+            subtitle = null;
+        }
+
+        this.titleLabel.label = title;
+        this.subtitleLabel.visible = (subtitle !== null);
+
+        if(subtitle)
+            this.subtitleLabel.label = subtitle;
+    }
+
+    _createWidgetForWindow(window)
+    {
+        let box = new Gtk.Box ({
+            orientation: Gtk.Orientation.VERTICAL,
+            valign: Gtk.Align.CENTER
+        });
+
+        this.titleLabel = new Gtk.Label({
+            halign: Gtk.Align.CENTER,
+            single_line_mode: true,
+            ellipsize: Pango.EllipsizeMode.END,
+            width_chars: 5,
+        });
+        this.titleLabel.add_css_class('title');
+        this.titleLabel.set_parent(box);
+
+        window.bind_property('title', this.titleLabel, 'label',
+            GObject.BindingFlags.SYNC_CREATE
+        );
+
+        this.subtitleLabel = new Gtk.Label({
+            halign: Gtk.Align.CENTER,
+            single_line_mode: true,
+            ellipsize: Pango.EllipsizeMode.END,
+        });
+        this.subtitleLabel.add_css_class('subtitle');
+        this.subtitleLabel.set_parent(box);
+        this.subtitleLabel.visible = false;
+
+        return box;
+    }
+});

--- a/clapper_src/headerbar.js
+++ b/clapper_src/headerbar.js
@@ -20,8 +20,9 @@ class ClapperHeaderBar extends Gtk.HeaderBar
         let subtitle = mediaInfo.get_uri() || null;
 
         if(subtitle && subtitle.startsWith('file://')) {
-            subtitle = GLib.filename_from_uri(subtitle)[0];
-            subtitle = GLib.path_get_basename(subtitle);
+            subtitle = GLib.path_get_basename(
+                GLib.filename_from_uri(subtitle)[0]
+            );
         }
 
         if(!title) {

--- a/clapper_src/interface.js
+++ b/clapper_src/interface.js
@@ -453,16 +453,12 @@ class ClapperInterface extends Gtk.Grid
             : 'overamplified';
 
         let iconName = `audio-volume-${icon}-symbolic`;
-/*
-        if(this.controls.volumeButton.image.icon_name !== iconName)
+        if(this.controls.volumeButton.icon_name !== iconName)
         {
             debug(`set volume icon: ${icon}`);
-            this.controls.volumeButton.image.set_from_icon_name(
-                iconName,
-                this.controls.volumeButton.image.icon_size
-            );
+            this.controls.volumeButton.set_icon_name(iconName);
         }
-*/
+
         if(volume === this.lastVolumeValue)
             return;
 

--- a/clapper_src/interface.js
+++ b/clapper_src/interface.js
@@ -51,11 +51,10 @@ class ClapperInterface extends Gtk.Grid
         this._player.connect('volume-changed', this._onPlayerVolumeChanged.bind(this));
         this._player.connect('duration-changed', this._onPlayerDurationChanged.bind(this));
         this._player.connect('position-updated', this._onPlayerPositionUpdated.bind(this));
-/*
-        this._player.connectWidget(
-            'scroll-event', (self, event) => this.controls._onScrollEvent(event)
+
+        this._player.scrollController.connect(
+            'scroll', (ctl, dx, dy) => this.controls._onScroll(ctl, dx, dy)
         );
-*/
         this.controls.togglePlayButton.connect(
             'clicked', this._onControlsTogglePlayClicked.bind(this)
         );

--- a/clapper_src/interface.js
+++ b/clapper_src/interface.js
@@ -350,10 +350,10 @@ class ClapperInterface extends Gtk.Grid
             case GstPlayer.PlayerState.STOPPED:
                 this.needsTracksUpdate = true;
             case GstPlayer.PlayerState.PAUSED:
-                this.controls.togglePlayButton.setPlayImage();
+                this.controls.togglePlayButton.setPrimaryIcon();
                 break;
             case GstPlayer.PlayerState.PLAYING:
-                this.controls.togglePlayButton.setPauseImage();
+                this.controls.togglePlayButton.setSecondaryIcon();
                 if(this.needsTracksUpdate) {
                     this.needsTracksUpdate = false;
                     this.updateMediaTracks();

--- a/clapper_src/interface.js
+++ b/clapper_src/interface.js
@@ -19,7 +19,7 @@ class ClapperInterface extends Gtk.Grid
         };
         Object.assign(this, defaults, opts);
 
-        this.controlsInVideo = false;
+        this.fullscreenMode = false;
         this.lastVolumeValue = null;
         this.lastPositionValue = 0;
         this.lastRevealerEventTime = 0;
@@ -38,7 +38,7 @@ class ClapperInterface extends Gtk.Grid
         this.attach(this.videoBox, 0, 0, 1, 1);
         this.attach(this.controls, 0, 1, 1, 1);
 
-        this.destroySignal = this.connect('destroy', this._onInterfaceDestroy.bind(this));
+        this.destroySignal = this.connect('destroy', this._onDestroy.bind(this));
     }
 
     addPlayer(player)
@@ -102,24 +102,25 @@ class ClapperInterface extends Gtk.Grid
             this[`revealer${pos}`].showChild(isShow);
     }
 
-    setControlsOnVideo(isOnVideo)
+    setFullscreenMode(isFullscreen)
     {
-        if(this.controlsInVideo === isOnVideo)
+        if(this.fullscreenMode === isFullscreen)
             return;
 
-        if(isOnVideo) {
+        if(isFullscreen) {
             this.remove(this.controls);
-            this.controls.pack_start(this.controls.unfullscreenButton.box, false, false, 0);
-            this.revealerBottom.addWidget(this.controls);
+            this.revealerBottom.append(this.controls);
         }
         else {
-            this.revealerBottom.removeWidget(this.controls);
-            this.controls.remove(this.controls.unfullscreenButton.box);
+            this.revealerBottom.remove(this.controls);
             this.attach(this.controls, 0, 1, 1, 1);
         }
 
-        this.controlsInVideo = isOnVideo;
-        debug(`placed controls in overlay: ${isOnVideo}`);
+        this.controls.setFullscreenMode(isFullscreen);
+        this.showControls(isFullscreen);
+
+        this.fullscreenMode = isFullscreen;
+        debug(`interface in fullscreen mode: ${isFullscreen}`);
     }
 
     updateMediaTracks()
@@ -212,7 +213,7 @@ class ClapperInterface extends Gtk.Grid
                 }
                 continue;
             }
-            this.controls.addRadioButtons(
+            this.controls.addCheckButtons(
                 this.controls[`${type}TracksButton`].popoverBox,
                 parsedInfo[`${type}Tracks`],
                 activeId
@@ -265,7 +266,7 @@ class ClapperInterface extends Gtk.Grid
                 });
             });
 
-            this.controls.addRadioButtons(
+            this.controls.addCheckButtons(
                 this.controls.visualizationsButton.popoverBox,
                 parsedVisArr,
                 null
@@ -433,7 +434,7 @@ class ClapperInterface extends Gtk.Grid
         this.lastPositionValue = positionSeconds;
         this._player.seek_seconds(positionSeconds);
 
-        if(this.controls.fullscreenMode)
+        if(this.fullscreenMode)
             this.updateTime();
     }
 
@@ -469,7 +470,7 @@ class ClapperInterface extends Gtk.Grid
         this._player.set_volume(volume);
     }
 
-    _onInterfaceDestroy()
+    _onDestroy()
     {
         this.disconnect(this.destroySignal);
         this.controls.emit('destroy');

--- a/clapper_src/player.js
+++ b/clapper_src/player.js
@@ -82,9 +82,11 @@ class ClapperPlayer extends GstPlayer.Player
 
         this.keyController = new Gtk.EventControllerKey();
         this.motionController = new Gtk.EventControllerMotion();
+        this.dragGesture = new Gtk.GestureDrag();
 
         this.widget.add_controller(this.keyController);
         this.widget.add_controller(this.motionController);
+        this.widget.add_controller(this.dragGesture);
 
         this.connect('state-changed', this._onStateChanged.bind(this));
         this.connect('uri-loaded', this._onUriLoaded.bind(this));

--- a/clapper_src/player.js
+++ b/clapper_src/player.js
@@ -1,4 +1,4 @@
-const { Gio, GLib, GObject, Gst, GstPlayer } = imports.gi;
+const { Gio, GLib, GObject, Gst, GstPlayer, Gtk } = imports.gi;
 const ByteArray = imports.byteArray;
 const Debug = imports.clapper_src.debug;
 
@@ -79,6 +79,12 @@ class ClapperPlayer extends GstPlayer.Player
         this._playlist = [];
         this._trackId = 0;
         this.playlist_ext = opts.playlist_ext || 'claps';
+
+        this.keyController = new Gtk.EventControllerKey();
+        this.motionController = new Gtk.EventControllerMotion();
+
+        this.widget.add_controller(this.keyController);
+        this.widget.add_controller(this.motionController);
 
         this.connect('state-changed', this._onStateChanged.bind(this));
         this.connect('uri-loaded', this._onUriLoaded.bind(this));

--- a/clapper_src/player.js
+++ b/clapper_src/player.js
@@ -21,7 +21,16 @@ class ClapperPlayer extends GstPlayer.Player
         if(!Gst.is_initialized())
             Gst.init(null);
 
-        let gtkglsink = Gst.ElementFactory.make('gtkglsink', null);
+        let plugin = 'gtk4glsink';
+        let gtkglsink = Gst.ElementFactory.make(plugin, null);
+
+        if(!gtkglsink) {
+            return debug(new Error(
+                `Could not load "${plugin}".`
+                    + ' Do you have gstreamer-plugins-good-gtk4 installed?'
+            ));
+        }
+
         let glsinkbin = Gst.ElementFactory.make('glsinkbin', null);
         glsinkbin.sink = gtkglsink;
 
@@ -35,8 +44,7 @@ class ClapperPlayer extends GstPlayer.Player
             video_renderer: renderer
         });
 
-        // assign elements to player for later access
-        // and make sure that GJS will not free them early
+        /* Assign elements to player for later access */
         this.gtkglsink = gtkglsink;
         this.glsinkbin = glsinkbin;
         this.dispatcher = dispatcher;
@@ -60,6 +68,10 @@ class ClapperPlayer extends GstPlayer.Player
 
         this.set_config(config);
         this.set_mute(false);
+
+        /* FIXME: remove once GUI buttons are back */
+        this.set_volume(0.5);
+        this.set_plugin_rank('vah264dec', 300);
 
         this.loop = GLib.MainLoop.new(null, false);
         this.run_loop = opts.run_loop || false;

--- a/clapper_src/player.js
+++ b/clapper_src/player.js
@@ -83,15 +83,18 @@ class ClapperPlayer extends GstPlayer.Player
         this.keyController = new Gtk.EventControllerKey();
         this.motionController = new Gtk.EventControllerMotion();
         this.scrollController = new Gtk.EventControllerScroll();
+        this.clickGesture = new Gtk.GestureClick();
         this.dragGesture = new Gtk.GestureDrag();
 
         this.scrollController.set_flags(
             Gtk.EventControllerScrollFlags.BOTH_AXES
         );
+        this.clickGesture.set_button(0);
 
         this.widget.add_controller(this.keyController);
         this.widget.add_controller(this.motionController);
         this.widget.add_controller(this.scrollController);
+        this.widget.add_controller(this.clickGesture);
         this.widget.add_controller(this.dragGesture);
 
         this.connect('state-changed', this._onStateChanged.bind(this));

--- a/clapper_src/player.js
+++ b/clapper_src/player.js
@@ -82,10 +82,16 @@ class ClapperPlayer extends GstPlayer.Player
 
         this.keyController = new Gtk.EventControllerKey();
         this.motionController = new Gtk.EventControllerMotion();
+        this.scrollController = new Gtk.EventControllerScroll();
         this.dragGesture = new Gtk.GestureDrag();
+
+        this.scrollController.set_flags(
+            Gtk.EventControllerScrollFlags.BOTH_AXES
+        );
 
         this.widget.add_controller(this.keyController);
         this.widget.add_controller(this.motionController);
+        this.widget.add_controller(this.scrollController);
         this.widget.add_controller(this.dragGesture);
 
         this.connect('state-changed', this._onStateChanged.bind(this));

--- a/clapper_src/player.js
+++ b/clapper_src/player.js
@@ -68,9 +68,6 @@ class ClapperPlayer extends GstPlayer.Player
 
         this.set_config(config);
         this.set_mute(false);
-
-        /* FIXME: remove once GUI buttons are back */
-        this.set_volume(0.5);
         this.set_plugin_rank('vah264dec', 300);
 
         this.loop = GLib.MainLoop.new(null, false);
@@ -86,6 +83,8 @@ class ClapperPlayer extends GstPlayer.Player
         this.connect('state-changed', this._onStateChanged.bind(this));
         this.connect('uri-loaded', this._onUriLoaded.bind(this));
         this.connect('end-of-stream', this._onStreamEnded.bind(this));
+        this.connect('warning', this._onPlayerWarning.bind(this));
+        this.connect('error', this._onPlayerError.bind(this));
         this.connectWidget('destroy', this._onWidgetDestroy.bind(this));
     }
 
@@ -251,6 +250,16 @@ class ClapperPlayer extends GstPlayer.Player
             && !this.loop.is_running()
         )
             this.loop.run();
+    }
+
+    _onPlayerWarning(self, error)
+    {
+        debug(error.message, 'LEVEL_WARNING');
+    }
+
+    _onPlayerError(self, error)
+    {
+        debug(error);
     }
 
     _onWidgetDestroy()

--- a/clapper_src/revealers.js
+++ b/clapper_src/revealers.js
@@ -200,6 +200,10 @@ class ClapperRevealerBottom extends CustomRevealer
         let isChange = super.set_visible(isVisible);
         if(!isChange) return;
 
+        let parent = this.get_parent();
+        let playerWidget = parent.get_first_child();
+        if(!playerWidget) return;
+
         if(isVisible) {
             let box = this.get_first_child();
             if(!box) return;
@@ -212,15 +216,12 @@ class ClapperRevealerBottom extends CustomRevealer
                 togglePlayButton.grab_focus();
                 debug('focus moved to toggle play button');
             }
+            playerWidget.set_can_focus(false);
         }
         else {
-            let parent = this.get_parent();
-            let playerWidget = parent.get_first_child();
-
-            if(playerWidget) {
-                playerWidget.grab_focus();
-                debug('focus moved to player widget');
-            }
+            playerWidget.set_can_focus(true);
+            playerWidget.grab_focus();
+            debug('focus moved to player widget');
         }
     }
 });

--- a/clapper_src/revealers.js
+++ b/clapper_src/revealers.js
@@ -44,10 +44,12 @@ class ClapperCustomRevealer extends Gtk.Revealer
     set_visible(isVisible)
     {
         if(this.visible === isVisible)
-            return;
+            return false;
 
         super.set_visible(isVisible);
         debug(`${this.revealerName} revealer visible: ${isVisible}`);
+
+        return true;
     }
 
     _timedReveal(isReveal, time)
@@ -191,5 +193,34 @@ class ClapperRevealerBottom extends CustomRevealer
     remove(widget)
     {
         this.revealerBox.remove(widget);
+    }
+
+    set_visible(isVisible)
+    {
+        let isChange = super.set_visible(isVisible);
+        if(!isChange) return;
+
+        if(isVisible) {
+            let box = this.get_first_child();
+            if(!box) return;
+
+            let controls = box.get_first_child();
+            if(!controls) return;
+
+            let togglePlayButton = controls.get_first_child();
+            if(togglePlayButton) {
+                togglePlayButton.grab_focus();
+                debug('focus moved to toggle play button');
+            }
+        }
+        else {
+            let parent = this.get_parent();
+            let playerWidget = parent.get_first_child();
+
+            if(playerWidget) {
+                playerWidget.grab_focus();
+                debug('focus moved to player widget');
+            }
+        }
     }
 });

--- a/clapper_src/revealers.js
+++ b/clapper_src/revealers.js
@@ -130,7 +130,7 @@ class ClapperRevealerTop extends CustomRevealer
         });
 
         this.revealerName = 'top';
-
+/*
         this.set_events(
             Gdk.EventMask.BUTTON_PRESS_MASK
             | Gdk.EventMask.BUTTON_RELEASE_MASK
@@ -141,7 +141,7 @@ class ClapperRevealerTop extends CustomRevealer
             | Gdk.EventMask.ENTER_NOTIFY_MASK
             | Gdk.EventMask.LEAVE_NOTIFY_MASK
         );
-
+*/
         let initTime = GLib.DateTime.new_now_local().format('%X');
         this.timeFormat = (initTime.length > 8)
             ? '%I:%M %p'
@@ -150,13 +150,13 @@ class ClapperRevealerTop extends CustomRevealer
         this.revealerGrid = new Gtk.Grid({
             column_spacing: 8
         });
-        let gridContext = this.revealerGrid.get_style_context();
-        gridContext.add_class('osd');
-        gridContext.add_class('reavealertop');
+        this.revealerGrid.add_css_class('osd');
+        this.revealerGrid.add_css_class('reavealertop');
 
         this.mediaTitle = new Gtk.Label({
             ellipsize: Pango.EllipsizeMode.END,
-            expand: true,
+            vexpand: true,
+            hexpand: true,
             margin_top: 14,
             margin_start: 12,
             xalign: 0,
@@ -169,17 +169,17 @@ class ClapperRevealerTop extends CustomRevealer
             yalign: 0,
         };
         this.currentTime = new Gtk.Label(timeLabelOpts);
-        this.currentTime.get_style_context().add_class('osdtime');
+        this.currentTime.add_css_class('osdtime');
 
         this.endTime = new Gtk.Label(timeLabelOpts);
-        this.endTime.get_style_context().add_class('osdendtime');
+        this.endTime.add_css_class('osdendtime');
 
         this.revealerGrid.attach(this.mediaTitle, 0, 0, 1, 1);
         this.revealerGrid.attach(this.currentTime, 1, 0, 1, 1);
         this.revealerGrid.attach(this.endTime, 1, 0, 1, 1);
 
-        this.add(this.revealerGrid);
-        this.revealerGrid.show_all();
+        this.set_child(this.revealerGrid);
+        //this.revealerGrid.show_all();
     }
 
     setMediaTitle(title)
@@ -217,10 +217,10 @@ class ClapperRevealerBottom extends CustomRevealer
 
         this.revealerName = 'bottom';
         this.revealerBox = new Gtk.Box();
-        this.revealerBox.get_style_context().add_class('osd');
+        this.revealerBox.add_css_class('osd');
 
-        this.add(this.revealerBox);
-        this.revealerBox.show_all();
+        this.set_child(this.revealerBox);
+        //this.revealerBox.show_all();
     }
 
     addWidget(widget)

--- a/clapper_src/revealers.js
+++ b/clapper_src/revealers.js
@@ -10,6 +10,13 @@ class ClapperCustomRevealer extends Gtk.Revealer
 {
     _init(opts)
     {
+        opts = opts || {};
+
+        let defaults = {
+            visible: false,
+        };
+        Object.assign(opts, defaults);
+
         super._init(opts);
 
         this.revealerName = '';

--- a/clapper_src/revealers.js
+++ b/clapper_src/revealers.js
@@ -220,15 +220,14 @@ class ClapperRevealerBottom extends CustomRevealer
         this.revealerBox.add_css_class('osd');
 
         this.set_child(this.revealerBox);
-        //this.revealerBox.show_all();
     }
 
-    addWidget(widget)
+    append(widget)
     {
-        this.revealerBox.pack_start(widget, false, true, 0);
+        this.revealerBox.append(widget);
     }
 
-    removeWidget(widget)
+    remove(widget)
     {
         this.revealerBox.remove(widget);
     }

--- a/clapper_src/window.js
+++ b/clapper_src/window.js
@@ -13,14 +13,11 @@ var Window = GObject.registerClass({
         super._init({
             application: application,
             title: title || 'Clapper',
-            //border_width: 0,
             resizable: true,
-            //window_position: Gtk.WindowPosition.CENTER,
-            width_request: 960,
-            height_request: 642,
             destroy_with_parent: true,
         });
         this.isFullscreen = false;
+        this.mapSignal = this.connect('map', this._onMap.bind(this));
     }
 
     toggleFullscreen()
@@ -28,15 +25,11 @@ var Window = GObject.registerClass({
         let un = (this.isFullscreen) ? 'un' : '';
         this[`${un}fullscreen`]();
     }
-/*
-    vfunc_window_state_event(event)
-    {
-        super.vfunc_window_state_event(event);
 
-        let isFullscreen = Boolean(
-            event.new_window_state
-            & Gdk.WindowState.FULLSCREEN
-        );
+    _onStateNotify(toplevel)
+    {
+        let { state } = toplevel;
+        let isFullscreen = Boolean(state & Gdk.ToplevelState.FULLSCREEN);
 
         if(this.isFullscreen === isFullscreen)
             return;
@@ -44,5 +37,12 @@ var Window = GObject.registerClass({
         this.isFullscreen = isFullscreen;
         this.emit('fullscreen-changed', this.isFullscreen);
     }
-*/
+
+    _onMap()
+    {
+        this.disconnect(this.mapSignal);
+
+        let surface = this.get_surface();
+        surface.connect('notify::state', this._onStateNotify.bind(this));
+    }
 });

--- a/clapper_src/window.js
+++ b/clapper_src/window.js
@@ -28,8 +28,9 @@ var Window = GObject.registerClass({
 
     _onStateNotify(toplevel)
     {
-        let { state } = toplevel;
-        let isFullscreen = Boolean(state & Gdk.ToplevelState.FULLSCREEN);
+        let isFullscreen = Boolean(
+            toplevel.state & Gdk.ToplevelState.FULLSCREEN
+        );
 
         if(this.isFullscreen === isFullscreen)
             return;

--- a/clapper_src/window.js
+++ b/clapper_src/window.js
@@ -13,11 +13,12 @@ var Window = GObject.registerClass({
         super._init({
             application: application,
             title: title || 'Clapper',
-            border_width: 0,
+            //border_width: 0,
             resizable: true,
-            window_position: Gtk.WindowPosition.CENTER,
+            //window_position: Gtk.WindowPosition.CENTER,
             width_request: 960,
-            height_request: 642
+            height_request: 642,
+            destroy_with_parent: true,
         });
         this.isFullscreen = false;
     }
@@ -27,7 +28,7 @@ var Window = GObject.registerClass({
         let un = (this.isFullscreen) ? 'un' : '';
         this[`${un}fullscreen`]();
     }
-
+/*
     vfunc_window_state_event(event)
     {
         super.vfunc_window_state_event(event);
@@ -43,4 +44,5 @@ var Window = GObject.registerClass({
         this.isFullscreen = isFullscreen;
         this.emit('fullscreen-changed', this.isFullscreen);
     }
+*/
 });

--- a/clapper_src/window.js
+++ b/clapper_src/window.js
@@ -17,6 +17,10 @@ var Window = GObject.registerClass({
             destroy_with_parent: true,
         });
         this.isFullscreen = false;
+
+        this.keyController = new Gtk.EventControllerKey();
+        this.add_controller(this.keyController);
+
         this.mapSignal = this.connect('map', this._onMap.bind(this));
     }
 

--- a/clapper_src/window.js
+++ b/clapper_src/window.js
@@ -17,10 +17,6 @@ var Window = GObject.registerClass({
             destroy_with_parent: true,
         });
         this.isFullscreen = false;
-
-        this.keyController = new Gtk.EventControllerKey();
-        this.add_controller(this.keyController);
-
         this.mapSignal = this.connect('map', this._onMap.bind(this));
     }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -39,7 +39,7 @@ scale marks {
   background: black;
 }
 .reavealertop {
-  min-height: 100px;
+  min-height: 90px;
   box-shadow: inset 0px 200px 10px -124px rgba(0,0,0,0.3);
   font-family: 'Cantarell', 'Noto Sans', sans-serif;
   font-size: 30px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -24,6 +24,11 @@ scale marks {
   min-width: 18px;
   min-height: 18px;
 }
+.labelbutton {
+  font-family: 'Cantarell', 'Noto Sans', sans-serif;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
 .videobox {
   background: black;
 }
@@ -45,25 +50,13 @@ scale marks {
   font-size: 24px;
   font-weight: 600;
 }
-
-/* Position Scale */
-.positionscale value {
-  font-weight: 600;
-  color: currentColor;
-}
-.positionscale trough highlight {
-  min-height: 4px;
-}
-.osd .positionscale value {
+.osd .labelbutton {
   font-size: 24px;
 }
-.positionscale contents {
-  margin-left: 4px;
-  margin-right: 2px;
-}
-.osd .positionscale contents {
-  margin-left: 8px;
-  margin-right: 2px;
+
+/* Position Scale */
+.positionscale trough highlight {
+  min-height: 4px;
 }
 .osd .positionscale trough slider {
   color: transparent;
@@ -77,12 +70,10 @@ scale marks {
 
 /* Volume Scale */
 .volumescale {
-  margin-left: 4px;
   min-height: 180px;
 }
 .osd .volumescale {
   margin: 6px;
-  margin-left: 10px;
   min-height: 280px;
 }
 .volumescale marks label {

--- a/css/styles.css
+++ b/css/styles.css
@@ -24,6 +24,12 @@ scale marks {
   min-width: 18px;
   min-height: 18px;
 }
+.playbackicon {
+  -gtk-icon-size: 20px;
+}
+.osd .playbackicon {
+  -gtk-icon-size: 28px;
+}
 .labelbutton {
   font-family: 'Cantarell', 'Noto Sans', sans-serif;
   font-variant-numeric: tabular-nums;

--- a/css/styles.css
+++ b/css/styles.css
@@ -8,7 +8,8 @@ scale marks {
   font-weight: 500;
 }
 .osd button {
-  margin: 2px;
+  margin-left: 1px;
+  margin-right: 1px;
   min-width: 36px;
   min-height: 36px;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -15,7 +15,7 @@ scale marks {
   min-height: 36px;
 }
 .osd scale trough highlight {
-  min-width: 6px;
+  min-width: 0px;
   min-height: 6px;
 }
 .osd radio {
@@ -89,4 +89,7 @@ scale marks {
 }
 .osd .volumescale marks label {
   margin-bottom: -8px;
+}
+.osd .volumescale trough highlight {
+  min-width: 6px;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -7,9 +7,10 @@ scale marks {
   font-size: 22px;
   font-weight: 500;
 }
+.osd .playercontrols {
+  -gtk-icon-size: 24px;
+}
 .osd button {
-  margin-left: 1px;
-  margin-right: 1px;
   min-width: 36px;
   min-height: 36px;
 }
@@ -28,7 +29,7 @@ scale marks {
 }
 .reavealertop {
   min-height: 100px;
-  box-shadow: inset 0px 200px 10px -124px rgba(0,0,0,0.4);
+  box-shadow: inset 0px 200px 10px -124px rgba(0,0,0,0.3);
   font-family: 'Cantarell', 'Noto Sans', sans-serif;
   font-size: 30px;
   font-weight: 500;

--- a/gjs-1.0/clapper.js.in
+++ b/gjs-1.0/clapper.js.in
@@ -1,5 +1,5 @@
-imports.gi.versions.Gdk = '3.0';
-imports.gi.versions.Gtk = '3.0';
+imports.gi.versions.Gdk = '4.0';
+imports.gi.versions.Gtk = '4.0';
 imports.searchPath.unshift('@importspath@');
 
 const ClapperSrc = imports.clapper_src;

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
-imports.gi.versions.Gdk = '3.0';
-imports.gi.versions.Gtk = '3.0';
+imports.gi.versions.Gdk = '4.0';
+imports.gi.versions.Gtk = '4.0';
 
 const { Gst } = imports.gi;
 const { App } = imports.clapper_src.app;

--- a/pkgs/arch/PKGBUILD
+++ b/pkgs/arch/PKGBUILD
@@ -27,13 +27,13 @@ arch=(any)
 url="https://github.com/Rafostar/clapper"
 license=("GPL-3.0")
 depends=(
-	"gtk3>=3.19.4"
+	"gtk4>=3.99.2"
 	"hicolor-icon-theme"
 	"gjs"
 	"gst-plugins-base-libs"
 	"gst-plugins-good"
-	"gst-plugins-bad-libs>=1.16.0"
-	"gst-plugin-gtk"
+	"gst-plugins-bad-libs>=1.18.0"
+	"gst-plugin-gtk4"
 )
 makedepends=(
 	"meson>=0.50"
@@ -44,7 +44,7 @@ optdepends=(
 	"gst-libav: Popular video decoders"
 	"gstreamer-vaapi: Intel/AMD video acceleration"
 )
-source=("${pkgname%-git}::git+https://github.com/Rafostar/${pkgname%-git}.git#branch=master")
+source=("${pkgname%-git}::git+https://github.com/Rafostar/${pkgname%-git}.git")
 provides=("${pkgname%-git}")
 replaces=("${pkgname%-git}")
 conflicts=("${pkgname%-git}")

--- a/pkgs/deb/debian/control
+++ b/pkgs/deb/debian/control
@@ -14,14 +14,14 @@ Build-Depends: debhelper (>= 10),
 Package: clapper
 Architecture: all
 Depends: gjs (>= 1.50),
-         gir1.2-gtk-3.0 (>= 3.19),
+         gir1.2-gtk-4.0 (>= 3.99.2),
          hicolor-icon-theme,
          libgstreamer1.0-0,
          gstreamer1.0-plugins-base,
          gstreamer1.0-plugins-good,
-         gstreamer1.0-plugins-bad (>= 1.16),
+         gstreamer1.0-plugins-bad (>= 1.18),
          gstreamer1.0-gl,
-         gstreamer1.0-gtk3
+         gstreamer1.0-gtk4
 Recommends: gstreamer1.0-libav,
             gstreamer1.0-pulseaudio
 Suggests: gstreamer-plugins-ugly,

--- a/pkgs/rpm/clapper.spec
+++ b/pkgs/rpm/clapper.spec
@@ -19,8 +19,8 @@
 
 
 %global appname com.github.rafostar.Clapper
-%global gst_version 1.16.0
-%global gtk3_version 3.19.4
+%global gst_version 1.18.0
+%global gtk4_version 3.99.2
 
 Name:           clapper
 Version:        0.0.0
@@ -39,7 +39,7 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  hicolor-icon-theme
 
 Requires:       gjs
-Requires:       gtk3 >= %{gtk3_version}
+Requires:       gtk4 >= %{gtk4_version}
 Requires:       hicolor-icon-theme
 
 %if 0%{?suse_version}
@@ -51,7 +51,7 @@ BuildRequires:  update-desktop-files
 Requires:       gstreamer
 Requires:       gstreamer-plugins-base
 Requires:       gstreamer-plugins-good
-Requires:       gstreamer-plugins-good-gtk
+Requires:       gstreamer-plugins-good-gtk4
 Requires:       gstreamer-plugins-bad
 Requires:       libgstplayer-1_0-0 >= %{gst_version}
 
@@ -62,14 +62,12 @@ Recommends:     gstreamer-plugins-libav
 Suggests:       gstreamer-plugins-ugly
 # Intel/AMD video acceleration
 Suggests:       gstreamer-plugins-vaapi
-%endif
-
-%if 0%{?fedora} || 0%{?rhel_version} || 0%{?centos_version}
+%else
 BuildRequires:  glibc-all-langpacks
 Requires:       gstreamer1
 Requires:       gstreamer1-plugins-base
 Requires:       gstreamer1-plugins-good
-Requires:       gstreamer1-plugins-good-gtk
+Requires:       gstreamer1-plugins-good-gtk4
 # Contains GstPlayer lib
 Requires:       gstreamer1-plugins-bad-free >= %{gst_version}
 
@@ -113,7 +111,11 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_datadir}/mime/packages/%{appname}.xml
 
 %changelog
+* Wed Oct 14 2020 Rafostar <rafostar.github@gmail.com> - 0.0.0-3
+- Update to GTK4
+
 * Sat Sep 19 22:02:00 CEST 2020 sp1rit - 0.0.0-2
 - Added suse_update_desktop_file macro for SuSE packages
+
 * Fri Sep 18 2020 Rafostar <rafostar.github@gmail.com> - 0.0.0-1
 - Initial package


### PR DESCRIPTION
We are moving to GTK4! Porting took a little longer than expected, cause I had to port GStreamer first. This change will be problematic for users of non-rolling linux distros, but its worth it. Both GTK4 and GStreamer 1.18+ have important GL changes. Clapper player takes full advantage of them.