### PR TITLE
Fix mobile devices transitions and detection

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -28,6 +28,8 @@ class ClapperControls extends Gtk.Box
         this.currentPosition = 0;
         this.currentDuration = 0;
         this.isPositionDragging = false;
+
+        this.isMobileMonitor = false;
         this.isMobile = false;
 
         this.showHours = false;

--- a/src/controls.js
+++ b/src/controls.js
@@ -509,10 +509,9 @@ class ClapperControls extends Gtk.Box
             : Misc.getCubicValue(settings.get_double('volume-last'));
 
         this.volumeScale.set_value(initialVolume);
-        player.widget.connect('resize', this._onPlayerResize.bind(this));
     }
 
-    _onPlayerResize(widget, width, height)
+    _onPlayerResize(width, height)
     {
         const isMobile = (width < 560);
         if(this.isMobile === isMobile)

--- a/src/widget.js
+++ b/src/widget.js
@@ -571,11 +571,18 @@ class ClapperWidget extends Gtk.Grid
         const geometry = monitor.geometry;
         const size = this.windowSize;
 
-        debug(`detected monitor resolution: ${geometry.width}x${geometry.height}`);
+        debug(`monitor application-pixels: ${geometry.width}x${geometry.height}`);
 
         if(geometry.width >= size[0] && geometry.height >= size[1]) {
             root.set_default_size(size[0], size[1]);
             debug(`restored window size: ${size[0]}x${size[1]}`);
+        }
+
+        const monitorWidth = Math.max(geometry.width, geometry.height);
+
+        if(monitorWidth < 1280) {
+            this.controls.isMobileMonitor = true;
+            debug('mobile monitor detected');
         }
 
         surface.connect('notify::state', this._onStateNotify.bind(this));

--- a/src/widget.js
+++ b/src/widget.js
@@ -21,6 +21,7 @@ class ClapperWidget extends Gtk.Grid
 
         this.windowSize = JSON.parse(settings.get_string('window-size'));
         this.floatSize = JSON.parse(settings.get_string('float-size'));
+        this.layoutWidth = 0;
 
         this.fullscreenMode = false;
         this.floatingMode = false;
@@ -549,6 +550,15 @@ class ClapperWidget extends Gtk.Grid
         debug(`interface in fullscreen mode: ${isFullscreen}`);
     }
 
+    _onLayoutUpdate(surface, width, height)
+    {
+        if(width === this.layoutWidth)
+            return;
+
+        this.layoutWidth = width;
+        this.controls._onPlayerResize(width, height);
+    }
+
     _onLeave(controller)
     {
         if(
@@ -586,5 +596,6 @@ class ClapperWidget extends Gtk.Grid
         }
 
         surface.connect('notify::state', this._onStateNotify.bind(this));
+        surface.connect('layout', this._onLayoutUpdate.bind(this));
     }
 });


### PR DESCRIPTION
On mobile devices "resize" signal does not work the same. Player needs to observe its surface layout instead. Also use display application-pixels to determine if used on a mobile device (right now unused, but needed for future).

Fixes #38