### PR TITLE
Parse mobile youtube URLs

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -975,6 +975,7 @@ function checkYouTubeUri(uri)
     switch(host) {
         case 'www.youtube.com':
         case 'youtube.com':
+        case 'm.youtube.com':
             videoId = gstUri.get_query_value('v');
             if(!videoId) {
                 /* Handle embedded videos */


### PR DESCRIPTION
Add support for youtube URLs with the format m.youtube.com?v=<video id>. Previously the video was not played when a mobile youtube URL link was used.