### PR TITLE
specfile improvements

### DIFF
--- a/_service
+++ b/_service
@@ -4,6 +4,11 @@
     <param name="url">https://github.com/Rafostar/clapper.git</param>
     <param name="extract">pkgs/rpm/clapper.spec</param>
     <param name="extract">pkgs/rpm/clapper.rpmlintrc</param>
+    <param name="versionformat">@PARENT_TAG@+git.@TAG_OFFSET@~%h</param>
+    <param name="changesgenerate">disable</param>
+    <param name="changesauthor">Rafostar &lt;rafostar.github@gmail.com&gt;</param>
+    <!--param name="revision">0.3.0</param>
+    <param name="version">0.3.0</param-->
   </service>
   <service name="tar" mode="buildtime"/>
   <service name="recompress" mode="buildtime">

--- a/pkgs/rpm/clapper.rpmlintrc
+++ b/pkgs/rpm/clapper.rpmlintrc
@@ -1,1 +1,1 @@
-addFilter("explicit-lib-dependency")
+


### PR DESCRIPTION
 + split lang files into seperate clapper-lang subpackage
  + split devel files into seperate clapper-devel subpackage
  + split typelib into seperate typelib-1_0-GstClapper-1_0 package on openSUSE
  + moved from %setup source dir hack to %autosetup with archive