### PR TITLE
Add playbin3 and PipeWire options to prefs

### DIFF
--- a/data/com.github.rafostar.Clapper.gschema.xml
+++ b/data/com.github.rafostar.Clapper.gschema.xml
@@ -94,6 +94,14 @@
       <default>'{}'</default>
       <summary>Custom values for GStreamer plugin ranking</summary>
     </key>
+    <key name="use-playbin3" type="b">
+      <default>false</default>
+      <summary>Use playbin3 element instead of playbin2</summary>
+    </key>
+    <key name="use-pipewire" type="b">
+      <default>false</default>
+      <summary>Use PipeWire for audio output</summary>
+    </key>
     <key name="play-flags" type="i">
       <default>1687</default>
       <summary>Set PlayFlags for playbin</summary>

--- a/lib/gst/clapper/gstclapper.c
+++ b/lib/gst/clapper/gstclapper.c
@@ -3158,8 +3158,14 @@ gst_clapper_main (gpointer data)
     if (pipewiresink) {
       g_object_set (self->playbin, "audio-sink", pipewiresink, NULL);
     } else {
-      g_warning ("GstClapper: pipewiresink element not available. "
-          "Default audio sink will be used instead.");
+      GstElement *fakesink;
+
+      g_warning ("GstClapper: pipewiresink element not available");
+      fakesink = gst_element_factory_make ("fakesink", "fakeaudiosink");
+      if (fakesink)
+        g_object_set (self->playbin, "audio-sink", fakesink, NULL);
+      else
+        g_warning ("GstClapper: default audio sink will be used instead");
     }
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -34,6 +34,8 @@ class ClapperPlayer extends GstClapper.Clapper
                 desktop_entry: Misc.appId,
                 default_art_url: Misc.getClapperThemeIconUri(),
             }),
+            use_playbin3: settings.get_boolean('use-playbin3'),
+            use_pipewire: settings.get_boolean('use-pipewire'),
         });
 
         this.widget = gtk4plugin.video_sink.widget;

--- a/ui/preferences-window.ui
+++ b/ui/preferences-window.ui
@@ -254,6 +254,20 @@
                 <property name="subtitle" translatable="yes">Alter default ranks of GStreamer plugins</property>
               </object>
             </child>
+            <child>
+              <object class="ClapperPrefsSwitch">
+                <property name="title" translatable="yes">Use playbin3</property>
+                <property name="subtitle" translatable="yes">Use experimental playbin3 element (requires player restart)</property>
+                <property name="schema-name">use-playbin3</property>
+              </object>
+            </child>
+            <child>
+              <object class="ClapperPrefsSwitch">
+                <property name="title" translatable="yes">Use PipeWire</property>
+                <property name="subtitle" translatable="yes">Use PipeWire for audio output (requires player restart)</property>
+                <property name="schema-name">use-pipewire</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>


### PR DESCRIPTION
Allow enabling playbin3 and PipeWire audio output from preferences window in addition to already existing env variables.