### PR TITLE
Update Flatpak Gnome runtime to V.41

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -11,7 +11,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-40
+      image: bilelmoussaoui/flatpak-github-actions:gnome-41
       options: --privileged
     strategy:
       matrix:


### PR DESCRIPTION
Most Gnome apps have moved to the 41 runtime. In my case at least this would be the only app still requiring the V.40 runtime. I don't think there is any reason to stay on V.40