### PR TITLE
plugin: Make modules management separate per instance

### DIFF
--- a/lib/gst/plugin/gstclapperimporterloader.h
+++ b/lib/gst/plugin/gstclapperimporterloader.h
@@ -25,12 +25,25 @@
 
 G_BEGIN_DECLS
 
-GstPadTemplate * gst_clapper_importer_loader_make_sink_pad_template          (void);
+#define GST_TYPE_CLAPPER_IMPORTER_LOADER (gst_clapper_importer_loader_get_type())
+G_DECLARE_FINAL_TYPE (GstClapperImporterLoader, gst_clapper_importer_loader, GST, CLAPPER_IMPORTER_LOADER, GstObject)
 
-gboolean         gst_clapper_importer_loader_find_importer_for_caps          (GstCaps *caps, GstClapperImporter **importer);
+#define GST_CLAPPER_IMPORTER_LOADER_CAST(obj)        ((GstClapperImporterLoader *)(obj))
 
-gboolean         gst_clapper_importer_loader_find_importer_for_context_query (GstQuery *query, GstClapperImporter **importer);
+struct _GstClapperImporterLoader
+{
+  GstObject parent;
 
-void             gst_clapper_importer_loader_unload_all                      (void);
+  GModule *last_module;
+  GPtrArray *importers;
+};
+
+GstClapperImporterLoader * gst_clapper_importer_loader_new                             (void);
+
+GstPadTemplate *           gst_clapper_importer_loader_make_sink_pad_template          (void);
+
+gboolean                   gst_clapper_importer_loader_find_importer_for_caps          (GstClapperImporterLoader *loader, GstCaps *caps, GstClapperImporter **importer);
+
+gboolean                   gst_clapper_importer_loader_find_importer_for_context_query (GstClapperImporterLoader *loader, GstQuery *query, GstClapperImporter **importer);
 
 G_END_DECLS

--- a/lib/gst/plugin/gstclappersink.h
+++ b/lib/gst/plugin/gstclappersink.h
@@ -25,6 +25,7 @@
 #include <gst/video/video.h>
 
 #include "gstclapperpaintable.h"
+#include "gstclapperimporterloader.h"
 #include "gstclapperimporter.h"
 
 G_BEGIN_DECLS
@@ -46,6 +47,7 @@ struct _GstClapperSink
   GMutex lock;
 
   GstClapperPaintable *paintable;
+  GstClapperImporterLoader *loader;
   GstClapperImporter *importer;
   GstVideoInfo v_info;
 


### PR DESCRIPTION
There were various problems with importer loader code. One defect was that
it kept managing a single global list of available importers and marking
which one is currently used on it. This made it not work correctly for
multiple sink instances in single process and was not thread safe.

This commit changes importer loader code into a GstObject subclass, which
keeps its own list of importers per instance and unlike before makes it
possible to free this data from memory when destroyed.

Now only open modules are kept always in memory until process finishes
since we cannot unload them once loaded anyway.