### PR TITLE
Fix caps negotiation on GLX

### DIFF
--- a/lib/gst/plugin/gstclapperimporter.h
+++ b/lib/gst/plugin/gstclapperimporter.h
@@ -36,7 +36,8 @@ G_BEGIN_DECLS
 #define GST_CLAPPER_IMPORTER_DEFINE(camel,lower,type)                     \
 G_DEFINE_TYPE (camel, lower, type)                                        \
 G_MODULE_EXPORT GstClapperImporter *make_importer (void);                 \
-G_MODULE_EXPORT GstCaps *make_caps (GstRank *rank, GStrv *context_types);
+G_MODULE_EXPORT GstCaps *make_caps (gboolean is_template,                 \
+    GstRank *rank, GStrv *context_types);
 
 typedef struct _GstClapperImporter GstClapperImporter;
 typedef struct _GstClapperImporterClass GstClapperImporterClass;

--- a/lib/gst/plugin/gstclapperimporterloader.h
+++ b/lib/gst/plugin/gstclapperimporterloader.h
@@ -42,6 +42,8 @@ GstClapperImporterLoader * gst_clapper_importer_loader_new                      
 
 GstPadTemplate *           gst_clapper_importer_loader_make_sink_pad_template          (void);
 
+GstCaps *                  gst_clapper_importer_loader_make_actual_caps                (GstClapperImporterLoader *loader);
+
 gboolean                   gst_clapper_importer_loader_find_importer_for_caps          (GstClapperImporterLoader *loader, GstCaps *caps, GstClapperImporter **importer);
 
 gboolean                   gst_clapper_importer_loader_find_importer_for_context_query (GstClapperImporterLoader *loader, GstQuery *query, GstClapperImporter **importer);

--- a/lib/gst/plugin/gstclappersink.c
+++ b/lib/gst/plugin/gstclappersink.c
@@ -412,7 +412,6 @@ static gboolean
 gst_clapper_sink_propose_allocation (GstBaseSink *bsink, GstQuery *query)
 {
   GstClapperSink *self = GST_CLAPPER_SINK_CAST (bsink);
-  GstBufferPool *pool = NULL;
   GstCaps *caps;
   GstVideoInfo info;
   guint size, min_buffers;
@@ -437,6 +436,7 @@ gst_clapper_sink_propose_allocation (GstBaseSink *bsink, GstQuery *query)
   min_buffers = 3;
 
   if (need_pool) {
+    GstBufferPool *pool;
     GstStructure *config = NULL;
 
     GST_DEBUG_OBJECT (self, "Need to create buffer pool");
@@ -458,15 +458,14 @@ gst_clapper_sink_propose_allocation (GstBaseSink *bsink, GstQuery *query)
         GST_ERROR_OBJECT (self, "Failed to set config");
         return FALSE;
       }
+
+      gst_query_add_allocation_pool (query, pool, size, min_buffers, 0);
+      gst_object_unref (pool);
     } else if (config) {
       GST_WARNING_OBJECT (self, "Got config without a pool to apply it");
       gst_structure_free (config);
     }
   }
-
-  gst_query_add_allocation_pool (query, pool, size, min_buffers, 0);
-  if (pool)
-    gst_object_unref (pool);
 
   GST_CLAPPER_SINK_LOCK (self);
   gst_clapper_importer_add_allocation_metas (self->importer, query);

--- a/lib/gst/plugin/gstclappersink.c
+++ b/lib/gst/plugin/gstclappersink.c
@@ -695,9 +695,10 @@ gst_clapper_sink_get_times (GstBaseSink *bsink, GstBuffer *buffer,
 static GstCaps *
 gst_clapper_sink_get_caps (GstBaseSink *bsink, GstCaps *filter)
 {
+  GstClapperSink *self = GST_CLAPPER_SINK_CAST (bsink);
   GstCaps *result, *tmp;
 
-  tmp = gst_pad_get_pad_template_caps (GST_BASE_SINK_PAD (bsink));
+  tmp = gst_clapper_importer_loader_make_actual_caps (self->loader);
 
   if (filter) {
     GST_DEBUG ("Intersecting with filter caps: %" GST_PTR_FORMAT, filter);

--- a/lib/gst/plugin/importers/gstclapperglimporter.c
+++ b/lib/gst/plugin/importers/gstclapperglimporter.c
@@ -61,7 +61,7 @@ make_importer (void)
 }
 
 GstCaps *
-make_caps (GstRank *rank, GStrv *context_types)
+make_caps (gboolean is_template, GstRank *rank, GStrv *context_types)
 {
   *rank = GST_RANK_SECONDARY;
   *context_types = gst_clapper_gl_base_importer_make_gl_context_types ();

--- a/lib/gst/plugin/importers/gstclappergluploader.c
+++ b/lib/gst/plugin/importers/gstclappergluploader.c
@@ -265,12 +265,12 @@ _update_glx_caps_on_main (GstCaps *caps)
 #endif
 
 GstCaps *
-make_caps (GstRank *rank, GStrv *context_types)
+make_caps (gboolean is_template, GstRank *rank, GStrv *context_types)
 {
   GstCaps *caps = gst_gl_upload_get_input_template_caps ();
 
 #if GST_CLAPPER_GL_BASE_IMPORTER_HAVE_X11_GLX
-  if (!(! !gst_gtk_invoke_on_main ((GThreadFunc) (GCallback)
+  if (!is_template && !(! !gst_gtk_invoke_on_main ((GThreadFunc) (GCallback)
       _update_glx_caps_on_main, caps)))
     gst_clear_caps (&caps);
 #endif

--- a/lib/gst/plugin/importers/gstclapperrawimporter.c
+++ b/lib/gst/plugin/importers/gstclapperrawimporter.c
@@ -97,7 +97,7 @@ make_importer (void)
 }
 
 GstCaps *
-make_caps (GstRank *rank, GStrv *context_types)
+make_caps (gboolean is_template, GstRank *rank, GStrv *context_types)
 {
   *rank = GST_RANK_MARGINAL;
 


### PR DESCRIPTION
GLX does not do DMABufs. New sink was using template caps when negotiating with downstream, due to that often ending up with DMABuf backed memory which is impossible on x11 with GLX. Use different, actually supported caps when negotiating.