### PR TITLE
controls: Use regular colon as time divider

### DIFF
--- a/src/buttons.js
+++ b/src/buttons.js
@@ -165,7 +165,7 @@ class ClapperElapsedTimeButton extends PopoverButtonBase
 
     setInitialState()
     {
-        this.label = '00∶00∕00∶00';
+        this.label = '00:00∕00:00';
     }
 
     setFullscreenMode(isFullscreen, isMobileMonitor)

--- a/src/controls.js
+++ b/src/controls.js
@@ -27,7 +27,7 @@ class ClapperControls extends Gtk.Box
         this.isMobile = false;
 
         this.showHours = false;
-        this.durationFormatted = '00∶00';
+        this.durationFormatted = '00:00';
         this.revealersArr = [];
         this.chapters = null;
 

--- a/src/misc.js
+++ b/src/misc.js
@@ -161,8 +161,8 @@ function getFormattedTime(time, showHours)
     time -= minutes * 60;
     const seconds = ('0' + Math.floor(time)).slice(-2);
 
-    const parsed = (hours) ? `${hours}∶` : '';
-    return parsed + `${minutes}∶${seconds}`;
+    const parsed = (hours) ? `${hours}:` : '';
+    return parsed + `${minutes}:${seconds}`;
 }
 
 function parsePlaylistFiles(filesArray)

--- a/src/revealers.js
+++ b/src/revealers.js
@@ -59,8 +59,8 @@ class ClapperRevealerTop extends CustomRevealer
 
         const initTime = GLib.DateTime.new_now_local().format('%X');
         this.timeFormat = (initTime.length > 8)
-            ? '%I∶%M %p'
-            : '%H∶%M';
+            ? '%I:%M %p'
+            : '%H:%M';
 
         this.mediaTitle = new Gtk.Label({
             ellipsize: Pango.EllipsizeMode.END,


### PR DESCRIPTION
Don't use ratio as time divider. Doing so causes
time to be displayed reversed in RTL languages.

Use „:” (U+003A) instead of „∶” (U+2236). This will fix
the reversed time in RTL languages.

See https://gitlab.gnome.org/Teams/Design/hig-www/-/issues/127
and https://gitlab.gnome.org/GNOME/gnome-music/-/issues/509

Signed-off-by: Yosef Or Boczko <yoseforb@gmail.com>