### PR TITLE
Use U+003A colon character on RTL languages

### DIFF
--- a/src/buttons.js
+++ b/src/buttons.js
@@ -165,7 +165,7 @@ class ClapperElapsedTimeButton extends PopoverButtonBase
 
     setInitialState()
     {
-        this.label = '00∶00∕00∶00';
+        this.label = `00${Misc.timeColon}00∕00${Misc.timeColon}00`;
     }
 
     setFullscreenMode(isFullscreen, isMobileMonitor)

--- a/src/controls.js
+++ b/src/controls.js
@@ -27,7 +27,7 @@ class ClapperControls extends Gtk.Box
         this.isMobile = false;
 
         this.showHours = false;
-        this.durationFormatted = '00∶00';
+        this.durationFormatted = `00${Misc.timeColon}00`;
         this.revealersArr = [];
         this.chapters = null;
 

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ Debug.debug('imports');
 
 const { GstClapper, Gtk, Adw } = imports.gi;
 const { App } = imports.src.app;
+const Misc = imports.src.misc;
 
 function main(argv)
 {
@@ -18,6 +19,10 @@ function main(argv)
     GstClapper.Clapper.gst_init(null);
     Gtk.init();
     Adw.init();
+
+    /* U+2236 seems to break RTL languages, use U+003A instead */
+    if(Gtk.Widget.get_default_direction() === Gtk.TextDirection.RTL)
+        Misc.timeColon = ':';
 
     Debug.debug('initialized');
 

--- a/src/misc.js
+++ b/src/misc.js
@@ -9,6 +9,7 @@ var subsMimes = [
     'application/x-subrip',
     'text/x-ssa',
 ];
+var timeColon = '∶';
 
 var settings = new Gio.Settings({
     schema_id: appId,
@@ -161,8 +162,8 @@ function getFormattedTime(time, showHours)
     time -= minutes * 60;
     const seconds = ('0' + Math.floor(time)).slice(-2);
 
-    const parsed = (hours) ? `${hours}∶` : '';
-    return parsed + `${minutes}∶${seconds}`;
+    const parsed = (hours) ? `${hours}${timeColon}` : '';
+    return parsed + `${minutes}${timeColon}${seconds}`;
 }
 
 function parsePlaylistFiles(filesArray)

--- a/src/revealers.js
+++ b/src/revealers.js
@@ -59,8 +59,8 @@ class ClapperRevealerTop extends CustomRevealer
 
         const initTime = GLib.DateTime.new_now_local().format('%X');
         this.timeFormat = (initTime.length > 8)
-            ? '%I∶%M %p'
-            : '%H∶%M';
+            ? `%I${Misc.timeColon}%M %p`
+            : `%H${Misc.timeColon}%M`;
 
         this.mediaTitle = new Gtk.Label({
             ellipsize: Pango.EllipsizeMode.END,


### PR DESCRIPTION
Unfortunately U+2236 seems to break time labels on RTL languages. Check text direction at startup and select best one that works.