### PR TITLE
 flatpak: Add missing GVFS access permissions

### DIFF
--- a/pkgs/flatpak/com.github.rafostar.Clapper-nightly.json
+++ b/pkgs/flatpak/com.github.rafostar.Clapper-nightly.json
@@ -18,7 +18,9 @@
         "--device=all",
         "--filesystem=xdg-run/pipewire-0:ro",
         "--filesystem=xdg-videos",
+        "--filesystem=xdg-run/gvfsd",
         "--own-name=org.mpris.MediaPlayer2.Clapper",
+        "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.gnome.Shell",
         "--env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0"
     ],

--- a/pkgs/flatpak/com.github.rafostar.Clapper.json
+++ b/pkgs/flatpak/com.github.rafostar.Clapper.json
@@ -14,7 +14,9 @@
         "--device=all",
         "--filesystem=xdg-run/pipewire-0:ro",
         "--filesystem=xdg-videos",
+        "--filesystem=xdg-run/gvfsd",
         "--own-name=org.mpris.MediaPlayer2.Clapper",
+        "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.gnome.Shell",
         "--env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0"
     ],


### PR DESCRIPTION
Needed to make GVFS mounted filesystems work with GVFS 1.48+.
See: https://docs.flatpak.org/en/latest/sandbox-permissions.html#gvfs-access