### PR TITLE
flatpak: Update to GNOME 43

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 600
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-42
+      image: bilelmoussaoui/flatpak-github-actions:gnome-43
       options: --privileged
     strategy:
       matrix:

--- a/pkgs/flatpak/com.github.rafostar.Clapper.json
+++ b/pkgs/flatpak/com.github.rafostar.Clapper.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.rafostar.Clapper",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
     "command": "com.github.rafostar.Clapper",
     "finish-args": [
@@ -34,7 +34,6 @@
         "flathub/lib/ffmpeg.json",
         "flathub/lib/uchardet.json",
         "flathub/gstreamer-1.0/gstreamer.json",
-        "flathub/lib/gtk4.json",
         "flathub/lib/libadwaita.json",
         "testing/gtuber.json",
         {


### PR DESCRIPTION
Update git actions builds to GNOME 43 runtime. With we can skip compiling GTK4 as the version included there doesn't need any patches anymore.