### PR TITLE
Add single-window setting (true by default).

### DIFF
--- a/data/com.github.rafostar.Clapper.gschema.xml
+++ b/data/com.github.rafostar.Clapper.gschema.xml
@@ -76,6 +76,10 @@
       <default>true</default>
       <summary>Enable rendering window shadows (only if theme has them)</summary>
     </key>
+    <key name="single-window" type="b">
+      <default>true</default>
+      <summary>Prevent more than one instance of clapper running at the same time. Required for Flatpak and MPRIS.</summary>
+    </key>
 
     <!-- GStreamer -->
     <key name="plugin-ranking" type="s">

--- a/src/app.js
+++ b/src/app.js
@@ -15,9 +15,12 @@ class ClapperApp extends Gtk.Application
 {
     _init()
     {
+        let flags = Gio.ApplicationFlags.HANDLES_OPEN;
+        if(!settings.get_boolean('single-window'))
+            flags |= Gio.ApplicationFlags.NON_UNIQUE;
         super._init({
             application_id: Misc.appId,
-            flags: Gio.ApplicationFlags.HANDLES_OPEN,
+            flags: flags,
         });
 
         this.doneFirstActivate = false;

--- a/ui/preferences-window.ui
+++ b/ui/preferences-window.ui
@@ -203,6 +203,15 @@
                 <property name="schema-name">render-shadows</property>
               </object>
             </child>
+            <child>
+              <object class="ClapperPrefsSwitch">
+                <property name="title" translatable="yes">Single window</property>
+                <property name="subtitle" translatable="yes">Required for Flatpak and MPRIS. Requires player restart.</property>
+                <property name="custom-icon-name">dialog-warning-symbolic</property>
+                <property name="custom-icon-subtitle" translatable="yes">Experimental</property>
+                <property name="schema-name">single-window</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>


### PR DESCRIPTION
By default, opening a second video with clapper will let the first clapper instance play that video while the second process exits.

Setting this to false, will open a new clapper window instead of replacing the video in an already running clapper process.

If dbus interaction is desired (for flatpak or mpris) then opening multiple windows like this will not work.

Closes: #76