### PR TITLE
Allow detecting and setting media rotation

### DIFF
--- a/lib/gst/plugin/gstclapperpaintable.h
+++ b/lib/gst/plugin/gstclapperpaintable.h
@@ -56,6 +56,7 @@ struct _GstClapperPaintable
 
   /* Sink properties */
   gint par_n, par_d;
+  GstVideoOrientationMethod rotation;
 
   /* Resize */
   gboolean pending_resize;
@@ -71,11 +72,13 @@ struct _GstClapperPaintable
   guint draw_id;
 };
 
-GstClapperPaintable * gst_clapper_paintable_new                    (void);
-void                  gst_clapper_paintable_queue_draw             (GstClapperPaintable *paintable);
-void                  gst_clapper_paintable_set_widget             (GstClapperPaintable *paintable, GtkWidget *widget);
-void                  gst_clapper_paintable_set_importer           (GstClapperPaintable *paintable, GstClapperImporter *importer);
-gboolean              gst_clapper_paintable_set_video_info         (GstClapperPaintable *paintable, const GstVideoInfo *v_info);
-void                  gst_clapper_paintable_set_pixel_aspect_ratio (GstClapperPaintable *paintable, gint par_n, gint par_d);
+GstClapperPaintable *      gst_clapper_paintable_new                    (void);
+void                       gst_clapper_paintable_queue_draw             (GstClapperPaintable *paintable);
+void                       gst_clapper_paintable_set_widget             (GstClapperPaintable *paintable, GtkWidget *widget);
+void                       gst_clapper_paintable_set_importer           (GstClapperPaintable *paintable, GstClapperImporter *importer);
+gboolean                   gst_clapper_paintable_set_video_info         (GstClapperPaintable *paintable, const GstVideoInfo *v_info);
+void                       gst_clapper_paintable_set_pixel_aspect_ratio (GstClapperPaintable *paintable, gint par_n, gint par_d);
+void                       gst_clapper_paintable_set_rotation           (GstClapperPaintable *paintable, GstVideoOrientationMethod rotation);
+GstVideoOrientationMethod  gst_clapper_paintable_get_rotation           (GstClapperPaintable *paintable);
 
 G_END_DECLS

--- a/lib/gst/plugin/gstclappersink.h
+++ b/lib/gst/plugin/gstclappersink.h
@@ -50,6 +50,7 @@ struct _GstClapperSink
   GstClapperImporterLoader *loader;
   GstClapperImporter *importer;
   GstVideoInfo v_info;
+  GstVideoOrientationMethod stream_orientation;
 
   GtkWidget *widget;
   GtkWindow *window;
@@ -58,6 +59,7 @@ struct _GstClapperSink
   gboolean force_aspect_ratio;
   gint par_n, par_d;
   gboolean keep_last_frame;
+  GstVideoOrientationMethod rotation_mode;
 
   /* Position coords */
   gdouble last_pos_x;

--- a/lib/gst/plugin/gstgtkutils.c
+++ b/lib/gst/plugin/gstgtkutils.c
@@ -140,3 +140,23 @@ gst_video_frame_into_gdk_texture (GstVideoFrame *frame)
 
   return texture;
 }
+
+void
+gst_gtk_get_width_height_for_rotation (gint width, gint height,
+    gint *out_width, gint *out_height,
+    GstVideoOrientationMethod rotation)
+{
+  switch (rotation) {
+    case GST_VIDEO_ORIENTATION_90R:
+    case GST_VIDEO_ORIENTATION_90L:
+    case GST_VIDEO_ORIENTATION_UL_LR:
+    case GST_VIDEO_ORIENTATION_UR_LL:
+      *out_width = height;
+      *out_height = width;
+      break;
+    default:
+      *out_width = width;
+      *out_height = height;
+      break;
+  }
+}

--- a/lib/gst/plugin/gstgtkutils.h
+++ b/lib/gst/plugin/gstgtkutils.h
@@ -32,4 +32,8 @@ gpointer        gst_gtk_invoke_on_main                (GThreadFunc func, gpointe
 
 GdkTexture *    gst_video_frame_into_gdk_texture      (GstVideoFrame *frame);
 
+void            gst_gtk_get_width_height_for_rotation (gint width, gint height,
+                                                       gint *out_width, gint *out_height,
+                                                       GstVideoOrientationMethod rotation);
+
 G_END_DECLS


### PR DESCRIPTION
Fixes #310

Rotation is done through GskTransforms directly on the Snapshot. 

The default behaviour is to autodetect the media rotation if available, but frontends can force it by setting the `rotation` property.

I've also exposed this to the actual app, but I'm unsure if that's wanted :sweat_smile:

This is how it looks now (playing the video from the aforementioned bug report):

[Video del 2023-04-01 15-36-57.webm](https://user-images.githubusercontent.com/92799/229292631-562b4cf8-ff7b-421b-8e45-c389e838c9c5.webm)

Thanks for your work on clapper!
