### PR TITLE
webServer: Listen on all interfaces

### DIFF
--- a/src/webServer.js
+++ b/src/webServer.js
@@ -48,7 +48,7 @@ class ClapperWebServer extends Soup.Server
         this.add_websocket_handler('/websocket', null, null, this._onWsConnection.bind(this));
 
         try {
-            isListening = this.listen_local(this.listeningPort, Soup.ServerListenOptions.IPV4_ONLY);
+            isListening = this.listen_all(this.listeningPort, Soup.ServerListenOptions.IPV4_ONLY);
         }
         catch(err) {
             debug(err);


### PR DESCRIPTION
Listen on all network interfaces for incoming connections.

Previous soup_server_listen_local() only listens on local loopback device preventing access from network, so use listen_all() instead to allow access through any interface.