### PR TITLE
Add standard shortcut for preferences

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -7,7 +7,7 @@ var actions = {
     open_local: ['<Ctrl>O'],
     export_playlist: ['<Ctrl>E'],
     open_uri: ['<Ctrl>U'],
-    prefs: null,
+    prefs: ['<Ctrl>comma'],
     shortcuts: ['F1', '<Ctrl>question'],
     about: null,
     progress_forward: ['Right'],

--- a/ui/help-overlay.ui
+++ b/ui/help-overlay.ui
@@ -16,6 +16,12 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Open preferences</property>
+                <property name="accelerator">&lt;Ctrl&gt;comma</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Toggle fullscreen</property>
                 <property name="subtitle" translatable="yes">Double tap | Double click</property>
                 <property name="accelerator">F11 f</property>


### PR DESCRIPTION
Many programs on GNOME use <kbd>Ctrl</kbd>+<kbd>,</kbd> to open Preferences. I've added this feature.