### PR TITLE
Update navigation and add description for plugin ranking preferences

### DIFF
--- a/ui/preferences-plugin-ranking-subpage.ui
+++ b/ui/preferences-plugin-ranking-subpage.ui
@@ -5,25 +5,28 @@
     <property name="vexpand">True</property>
     <property name="hexpand">True</property>
     <child>
-      <object class="AdwPreferencesPage">
-        <child>
-          <object class="AdwPreferencesGroup" id="decoders_group">
-            <property name="title" translatable="yes">Decoders</property>
+      <object class="AdwHeaderBar">
+        <property name="title-widget">
+          <object class="AdwWindowTitle">
+            <property name="title" translatable="yes">Plugin ranking</property>
+          </object>
+        </property>
+        <child type="start">
+          <object class="GtkButton">
+            <property name="icon-name">go-previous-symbolic</property>
+            <signal name="clicked" handler="_onReturnClicked"/>
           </object>
         </child>
       </object>
     </child>
     <child>
-      <object class="GtkButton">
-        <property name="label" translatable="yes">Return to the preferences</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
-        <property name="margin_top">12</property>
-        <property name="margin_bottom">12</property>
-        <signal name="clicked" handler="_onReturnClicked"/>
-        <style>
-          <class name="suggested-action"/>
-        </style>
+      <object class="AdwPreferencesPage">
+        <child>
+          <object class="AdwPreferencesGroup" id="decoders_group">
+            <property name="title" translatable="yes">Decoders</property>
+            <property name="description">Overwrites decoder priorities. A value of 0 disables them entirely.</property>
+          </object>
+        </child>
       </object>
     </child>
   </template>


### PR DESCRIPTION
I added a more standard `AdwHeaderBar` object, and re-positioned the old back button. I also added a description to help users understand how the system works.

![Screenshot from 2023-09-06 18-42-15](https://github.com/Rafostar/clapper/assets/25536957/3e722498-7b14-46e2-92ee-1054519fb979)

I would have added a reset button and search bar if I could have figured it out. Sorry, I am new to GTK and JS.