### PR TITLE
clapper-gtk/extra-menu: Fixed speed being forced to the lowest value

### DIFF
--- a/src/lib/clapper-gtk/clapper-gtk-extra-menu-button.c
+++ b/src/lib/clapper-gtk/clapper-gtk-extra-menu-button.c
@@ -129,7 +129,7 @@ volume_spin_input_cb (GtkSpinButton *spin_button, gdouble *value, ClapperGtkExtr
 {
   const gchar *text = gtk_editable_get_text (GTK_EDITABLE (spin_button));
   gchar *sign = NULL;
-  gdouble volume = g_ascii_strtod (text, &sign);
+  gdouble volume = g_strtod (text, &sign);
 
   if (volume < 0 || volume > 200
       || (sign && sign[0] != '\0' && sign[0] != '%'))
@@ -174,7 +174,7 @@ speed_spin_input_cb (GtkSpinButton *spin_button, gdouble *value, ClapperGtkExtra
 {
   const gchar *text = gtk_editable_get_text (GTK_EDITABLE (spin_button));
   gchar *sign = NULL;
-  gdouble speed = g_ascii_strtod (text, &sign);
+  gdouble speed = g_strtod (text, &sign);
 
   if (speed < 0.05 || speed > 2.0
       || (sign && sign[0] != '\0' && sign[0] != 'x'))


### PR DESCRIPTION
Steps to reproduce the bug:
- <sub>if you have a reduced available localeset, first enable de_DE.UTF-8 and rerun localegen</sub>
- set LANG to `de_DE.UTF-8`
- run `clapper /path/to/media.ext`
- open the "extra menu button"
- press the "-" button on the playback speed selector
→ the playback speed is now set to the lowest value and changing it doesn't appear to work.  If media is running, attempting to scroll up the speed selector does change the value and speed up the media, but it always attempts to "move back" to the lowest value