### PR TITLE
clapper: Add media caching via download to local storage

### DIFF
--- a/examples/clapper-gtk/download_cache/python/example.py
+++ b/examples/clapper-gtk/download_cache/python/example.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import gi
+gi.require_version('Adw', '1')
+gi.require_version('Clapper', '0.0')
+gi.require_version('ClapperGtk', '0.0')
+gi.require_version('GLib', '2.0')
+gi.require_version('Gtk', '4.0')
+from gi.repository import Adw, Clapper, ClapperGtk, GLib, Gtk
+import shutil
+
+Clapper.init(None)
+
+download_dir = GLib.build_filenamev([GLib.get_user_cache_dir(), "example_download_dir", None])
+print('Using ceche directory: {0}'.format(download_dir))
+
+def on_download_complete(player, item, location):
+    # Media downloaded. Data from this file is still used for current playback (including seeking).
+    print('Download complete: {0} => {1}'.format(item.props.uri, location))
+
+def on_activate(app):
+    win = Gtk.ApplicationWindow(application=app, default_width=640, default_height=396)
+    video = ClapperGtk.Video()
+    controls = ClapperGtk.SimpleControls(fullscreenable=False)
+
+    # Enable local storage caching and monitor it
+    video.props.player.set_download_dir(download_dir)
+    video.props.player.set_download_enabled(True)
+    video.props.player.connect('download-complete', on_download_complete)
+
+    # Configure playback
+    video.props.player.props.queue.set_progression_mode(Clapper.QueueProgressionMode.CAROUSEL)
+    video.props.player.set_autoplay(True)
+
+    # Create and add media for playback
+    item_1 = Clapper.MediaItem(uri='http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4')
+    item_2 = Clapper.MediaItem(uri='http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4')
+    video.props.player.props.queue.add_item(item_1)
+    video.props.player.props.queue.add_item(item_2)
+
+    # Assemble window
+    video.add_fading_overlay(controls)
+    win.set_child(video)
+    win.present()
+
+# Create a new application
+app = Adw.Application(application_id='com.example.ClapperDownloadCache')
+app.connect('activate', on_activate)
+
+# Run the application
+app.run(None)
+
+# Finally app should cleanup before exit. Possibly moving data to
+# another dir if it wants to use it on next run and deleting what's
+# left (so any unfinished downloads will also be removed).
+print('Cleanup')
+shutil.rmtree(download_dir)

--- a/src/lib/clapper/clapper-app-bus-private.h
+++ b/src/lib/clapper/clapper-app-bus-private.h
@@ -47,6 +47,8 @@ void clapper_app_bus_post_refresh_timeline (ClapperAppBus *app_bus, GstObject *s
 
 void clapper_app_bus_post_simple_signal (ClapperAppBus *app_bus, GstObject *src, guint signal_id);
 
+void clapper_app_bus_post_object_desc_signal (ClapperAppBus *app_bus, GstObject *src, guint signal_id, GstObject *object, const gchar *desc);
+
 void clapper_app_bus_post_desc_with_details_signal (ClapperAppBus *app_bus, GstObject *src, guint signal_id, const gchar *desc, const gchar *details);
 
 void clapper_app_bus_post_error_signal (ClapperAppBus *app_bus, GstObject *src, guint signal_id, GError *error, const gchar *debug_info);

--- a/src/lib/clapper/clapper-media-item-private.h
+++ b/src/lib/clapper/clapper-media-item-private.h
@@ -38,6 +38,12 @@ G_GNUC_INTERNAL
 gboolean clapper_media_item_set_duration (ClapperMediaItem *item, gdouble duration, ClapperAppBus *app_bus);
 
 G_GNUC_INTERNAL
+void clapper_media_item_set_cache_location (ClapperMediaItem *item, const gchar *location);
+
+G_GNUC_INTERNAL
+const gchar * clapper_media_item_get_playback_uri (ClapperMediaItem *item);
+
+G_GNUC_INTERNAL
 void clapper_media_item_set_used (ClapperMediaItem *item, gboolean used);
 
 G_GNUC_INTERNAL

--- a/src/lib/clapper/clapper-playbin-bus.c
+++ b/src/lib/clapper/clapper-playbin-bus.c
@@ -827,6 +827,24 @@ _handle_element_msg (GstMessage *msg, ClapperPlayer *player)
 
     g_free (name);
     g_free (details);
+  } else if (gst_message_has_name (msg, "GstCacheDownloadComplete")) {
+    const GstStructure *structure;
+    const gchar *location;
+    guint signal_id;
+
+    if (G_UNLIKELY (player->played_item == NULL))
+      return;
+
+    structure = gst_message_get_structure (msg);
+    location = gst_structure_get_string (structure, "location");
+    signal_id = g_signal_lookup ("download-complete", CLAPPER_TYPE_PLAYER);
+
+    GST_INFO_OBJECT (player, "Download complete: %s", location);
+    clapper_media_item_set_cache_location (player->played_item, location);
+
+    clapper_app_bus_post_object_desc_signal (player->app_bus,
+        GST_OBJECT_CAST (player), signal_id,
+        GST_OBJECT_CAST (player->played_item), location);
   }
 }
 

--- a/src/lib/clapper/clapper-player-private.h
+++ b/src/lib/clapper/clapper-player-private.h
@@ -95,6 +95,8 @@ struct _ClapperPlayer
   gboolean video_enabled;
   gboolean audio_enabled;
   gboolean subtitles_enabled;
+  gchar *download_dir;
+  gboolean download_enabled;
   gdouble audio_offset;
   gdouble subtitle_offset;
 };

--- a/src/lib/clapper/clapper-player.h
+++ b/src/lib/clapper/clapper-player.h
@@ -101,6 +101,14 @@ void clapper_player_set_subtitles_enabled (ClapperPlayer *player, gboolean enabl
 
 gboolean clapper_player_get_subtitles_enabled (ClapperPlayer *player);
 
+void clapper_player_set_download_dir (ClapperPlayer *player, const gchar *path);
+
+gchar * clapper_player_get_download_dir (ClapperPlayer *player);
+
+void clapper_player_set_download_enabled (ClapperPlayer *player, gboolean enabled);
+
+gboolean clapper_player_get_download_enabled (ClapperPlayer *player);
+
 void clapper_player_set_audio_offset (ClapperPlayer *player, gdouble offset);
 
 gdouble clapper_player_get_audio_offset (ClapperPlayer *player);


### PR DESCRIPTION
The aim here is to stream an online video/audio while also at the
same time download/cache it to disk (excluding adaptive content).

After download is complete, further playback and seeking are done using the
locally cached file. This functionality uses GStreamer "downloadbuffer" element.

Player will emit a signal with a local download location after it completes,
so application will know where downloaded file for media item is stored in
case it wants to reuse it in the future.

It is up to application to set download dir and later manage downloaded
content in it, removing files its not going to use on next application
run and any incomplete downloads.