### PR TITLE
Add more command line options

### DIFF
--- a/src/bin/clapper-app/clapper-app-application.c
+++ b/src/bin/clapper-app/clapper-app-application.c
@@ -61,6 +61,7 @@ struct ClapperPluginData
 struct ClapperAppOptions
 {
   gdouble volume;
+  gdouble speed;
 
   gchar *video_filter;
   gchar *audio_filter;
@@ -273,7 +274,12 @@ _restore_settings_to_window (ClapperAppApplication *self, ClapperAppWindow *app_
     clapper_player_set_volume (player, PERCENTAGE_ROUND (g_settings_get_double (self->settings, "volume")));
 
   clapper_player_set_mute (player, g_settings_get_boolean (self->settings, "mute"));
-  clapper_player_set_speed (player, PERCENTAGE_ROUND (g_settings_get_double (self->settings, "speed")));
+
+  if (app_opts.speed >= 0)
+    clapper_player_set_speed (player, PERCENTAGE_ROUND (app_opts.speed));
+  else
+    clapper_player_set_speed (player, PERCENTAGE_ROUND (g_settings_get_double (self->settings, "speed")));
+
   clapper_player_set_subtitles_enabled (player, g_settings_get_boolean (self->settings, "subtitles-enabled"));
   clapper_queue_set_progression_mode (queue, g_settings_get_int (self->settings, "progression-mode"));
 
@@ -541,6 +547,7 @@ static void
 clapper_app_application_init (ClapperAppApplication *self)
 {
   app_opts.volume = -1;
+  app_opts.speed = -1;
 
   self->need_init_state = TRUE;
 }
@@ -554,6 +561,7 @@ clapper_app_application_constructed (GObject *object)
 
   const GOptionEntry app_options[] = {
     { "volume", 0, 0, G_OPTION_ARG_DOUBLE, &app_opts.volume, _("Audio volume to set (0 - 2.0 range)"), NULL },
+    { "speed", 0, 0, G_OPTION_ARG_DOUBLE, &app_opts.speed, _("Playback speed to set (0.05 - 2.0 range)"), NULL },
     { "video-filter", 0, 0, G_OPTION_ARG_STRING, &app_opts.video_filter, _("Video filter to use (\"none\" to disable)"), NULL },
     { "audio-filter", 0, 0, G_OPTION_ARG_STRING, &app_opts.audio_filter, _("Audio filter to use (\"none\" to disable)"), NULL },
     { "video-sink", 0, 0, G_OPTION_ARG_STRING, &app_opts.video_sink, _("Video sink to use"), NULL },

--- a/src/bin/clapper-app/clapper-app-application.c
+++ b/src/bin/clapper-app/clapper-app-application.c
@@ -76,6 +76,8 @@ struct ClapperAppOptions
 
   gint progression_mode;
 
+  gboolean fullscreen;
+
   gchar *video_filter;
   gchar *audio_filter;
 
@@ -290,7 +292,7 @@ _apply_settings_to_window (ClapperAppApplication *self, ClapperAppWindow *app_wi
   else
     clapper_queue_set_progression_mode (queue, g_settings_get_int (self->settings, "progression-mode"));
 
-  if (g_settings_get_boolean (self->settings, "fullscreened"))
+  if (app_opts->fullscreen || g_settings_get_boolean (self->settings, "fullscreened"))
     gtk_window_fullscreen (GTK_WINDOW (app_window));
   else if (g_settings_get_boolean (self->settings, "maximized"))
     gtk_window_maximize (GTK_WINDOW (app_window));
@@ -423,6 +425,8 @@ clapper_app_application_command_line (GApplication *app, GApplicationCommandLine
     app_opts.speed = -1;
   if (!g_variant_dict_lookup (options, "progression-mode", "i", &app_opts.progression_mode))
     app_opts.progression_mode = -1;
+
+  app_opts.fullscreen = g_variant_dict_contains (options, "fullscreen");
 
   g_variant_dict_lookup (options, "video-filter", "s", &app_opts.video_filter);
   g_variant_dict_lookup (options, "audio-filter", "s", &app_opts.audio_filter);
@@ -620,6 +624,7 @@ clapper_app_application_constructed (GObject *object)
     { "volume", 0, 0, G_OPTION_ARG_DOUBLE, NULL, _("Audio volume to set (0 - 2.0 range)"), NULL },
     { "speed", 0, 0, G_OPTION_ARG_DOUBLE, NULL, _("Playback speed to set (0.05 - 2.0 range)"), NULL },
     { "progression-mode", 0, 0, G_OPTION_ARG_INT, NULL, _("Initial queue progression mode (0=none, 1=consecutive, 2=repeat-item, 3=carousel, 4=shuffle)"), NULL },
+    { "fullscreen", 'f', 0, G_OPTION_ARG_NONE, NULL, _("Set window to be fullscreen"), NULL },
     { "video-filter", 0, 0, G_OPTION_ARG_STRING, NULL, _("Video filter to use (\"none\" to disable)"), NULL },
     { "audio-filter", 0, 0, G_OPTION_ARG_STRING, NULL, _("Audio filter to use (\"none\" to disable)"), NULL },
     { "video-sink", 0, 0, G_OPTION_ARG_STRING, NULL, _("Video sink to use"), NULL },

--- a/src/bin/clapper-app/clapper-app-application.c
+++ b/src/bin/clapper-app/clapper-app-application.c
@@ -60,6 +60,8 @@ struct ClapperPluginData
 
 struct ClapperAppOptions
 {
+  gdouble volume;
+
   gchar *video_filter;
   gchar *audio_filter;
 
@@ -264,7 +266,12 @@ _restore_settings_to_window (ClapperAppApplication *self, ClapperAppWindow *app_
   if (app_opts.audio_sink)
     clapper_player_set_audio_sink (player, clapper_app_utils_make_element (app_opts.audio_sink));
 
-  clapper_player_set_volume (player, PERCENTAGE_ROUND (g_settings_get_double (self->settings, "volume")));
+  /* NOTE: Not using ternary operator to avoid accidental typecasting */
+  if (app_opts.volume >= 0)
+    clapper_player_set_volume (player, PERCENTAGE_ROUND (app_opts.volume));
+  else
+    clapper_player_set_volume (player, PERCENTAGE_ROUND (g_settings_get_double (self->settings, "volume")));
+
   clapper_player_set_mute (player, g_settings_get_boolean (self->settings, "mute"));
   clapper_player_set_speed (player, PERCENTAGE_ROUND (g_settings_get_double (self->settings, "speed")));
   clapper_player_set_subtitles_enabled (player, g_settings_get_boolean (self->settings, "subtitles-enabled"));
@@ -533,6 +540,8 @@ clapper_app_application_open (GApplication *app,
 static void
 clapper_app_application_init (ClapperAppApplication *self)
 {
+  app_opts.volume = -1;
+
   self->need_init_state = TRUE;
 }
 
@@ -544,6 +553,7 @@ clapper_app_application_constructed (GObject *object)
   guint i;
 
   const GOptionEntry app_options[] = {
+    { "volume", 0, 0, G_OPTION_ARG_DOUBLE, &app_opts.volume, _("Audio volume to set (0 - 2.0 range)"), NULL },
     { "video-filter", 0, 0, G_OPTION_ARG_STRING, &app_opts.video_filter, _("Video filter to use (\"none\" to disable)"), NULL },
     { "audio-filter", 0, 0, G_OPTION_ARG_STRING, &app_opts.audio_filter, _("Audio filter to use (\"none\" to disable)"), NULL },
     { "video-sink", 0, 0, G_OPTION_ARG_STRING, &app_opts.video_sink, _("Video sink to use"), NULL },

--- a/src/bin/clapper-app/clapper-app-application.c
+++ b/src/bin/clapper-app/clapper-app-application.c
@@ -666,6 +666,8 @@ clapper_app_application_constructed (GObject *object)
   for (i = 0; i < G_N_ELEMENTS (app_shortcuts); ++i)
     gtk_application_set_accels_for_action (GTK_APPLICATION (app), app_shortcuts[i].action, app_shortcuts[i].accels);
 
+  g_application_set_option_context_parameter_string (app, "[URI1|FILE1] [URI2|FILE2] …");
+
   g_application_add_main_option_entries (app, app_options);
   g_application_add_option_group (app, gst_init_get_option_group ());
 

--- a/src/bin/clapper-app/clapper-app-application.c
+++ b/src/bin/clapper-app/clapper-app-application.c
@@ -419,11 +419,19 @@ clapper_app_application_command_line (GApplication *app, GApplicationCommandLine
     app_opts.enqueue = g_variant_dict_contains (options, "enqueue");
   }
 
-  if (!g_variant_dict_lookup (options, "volume", "d", &app_opts.volume))
+  if (g_variant_dict_lookup (options, "volume", "d", &app_opts.volume))
+    app_opts.volume = CLAMP (app_opts.volume, 0, 2.0); // clamp to allowed range
+  else
     app_opts.volume = -1;
-  if (!g_variant_dict_lookup (options, "speed", "d", &app_opts.speed))
+
+  if (g_variant_dict_lookup (options, "speed", "d", &app_opts.speed))
+    app_opts.speed = CLAMP (app_opts.speed, 0.05, 2.0); // clamp to allowed range
+  else
     app_opts.speed = -1;
-  if (!g_variant_dict_lookup (options, "progression-mode", "i", &app_opts.progression_mode))
+
+  if (g_variant_dict_lookup (options, "progression-mode", "i", &app_opts.progression_mode))
+    app_opts.progression_mode = CLAMP (app_opts.progression_mode, 0, 4); // clamp to possible modes
+  else
     app_opts.progression_mode = -1;
 
   app_opts.fullscreen = g_variant_dict_contains (options, "fullscreen");

--- a/src/bin/clapper-app/clapper-app-application.c
+++ b/src/bin/clapper-app/clapper-app-application.c
@@ -69,8 +69,6 @@ typedef struct
 
 struct ClapperAppOptions
 {
-  gboolean enqueue;
-
   gdouble volume;
   gdouble speed;
 
@@ -408,7 +406,7 @@ clapper_app_application_command_line (GApplication *app, GApplicationCommandLine
   GVariantDict *options;
   GFile **files = NULL;
   gint n_files = 0;
-  gboolean is_remote, restore;
+  gboolean is_remote, restore, enqueue = FALSE;
 
   GST_INFO ("Handling command line");
 
@@ -420,7 +418,7 @@ clapper_app_application_command_line (GApplication *app, GApplicationCommandLine
     if (g_variant_dict_contains (options, "new-window"))
       window = GTK_WINDOW (clapper_app_window_new (GTK_APPLICATION (app)));
 
-    app_opts.enqueue = g_variant_dict_contains (options, "enqueue");
+    enqueue = g_variant_dict_contains (options, "enqueue");
   }
 
   if (g_variant_dict_lookup (options, "volume", "d", &app_opts.volume))
@@ -447,7 +445,7 @@ clapper_app_application_command_line (GApplication *app, GApplicationCommandLine
   g_variant_dict_lookup (options, "audio-sink", "s", &app_opts.audio_sink);
 
   if (clapper_app_utils_files_from_command_line (cmd_line, &files, &n_files)) {
-    g_application_open (app, files, n_files, (app_opts.enqueue) ? "add-only" : "");
+    g_application_open (app, files, n_files, (enqueue) ? "add-only" : "");
     clapper_app_utils_files_free (files);
   } else {
     g_application_activate (app);

--- a/src/bin/clapper-app/clapper-app-application.c
+++ b/src/bin/clapper-app/clapper-app-application.c
@@ -74,6 +74,8 @@ struct ClapperAppOptions
   gdouble volume;
   gdouble speed;
 
+  gint progression_mode;
+
   gchar *video_filter;
   gchar *audio_filter;
 
@@ -282,7 +284,11 @@ _apply_settings_to_window (ClapperAppApplication *self, ClapperAppWindow *app_wi
     clapper_player_set_speed (player, PERCENTAGE_ROUND (g_settings_get_double (self->settings, "speed")));
 
   clapper_player_set_subtitles_enabled (player, g_settings_get_boolean (self->settings, "subtitles-enabled"));
-  clapper_queue_set_progression_mode (queue, g_settings_get_int (self->settings, "progression-mode"));
+
+  if (app_opts->progression_mode >= 0)
+    clapper_queue_set_progression_mode (queue, app_opts->progression_mode);
+  else
+    clapper_queue_set_progression_mode (queue, g_settings_get_int (self->settings, "progression-mode"));
 
   if (g_settings_get_boolean (self->settings, "fullscreened"))
     gtk_window_fullscreen (GTK_WINDOW (app_window));
@@ -415,6 +421,8 @@ clapper_app_application_command_line (GApplication *app, GApplicationCommandLine
     app_opts.volume = -1;
   if (!g_variant_dict_lookup (options, "speed", "d", &app_opts.speed))
     app_opts.speed = -1;
+  if (!g_variant_dict_lookup (options, "progression-mode", "i", &app_opts.progression_mode))
+    app_opts.progression_mode = -1;
 
   g_variant_dict_lookup (options, "video-filter", "s", &app_opts.video_filter);
   g_variant_dict_lookup (options, "audio-filter", "s", &app_opts.audio_filter);
@@ -611,6 +619,7 @@ clapper_app_application_constructed (GObject *object)
     { "enqueue", 0, 0, G_OPTION_ARG_NONE, NULL, _("Add media to queue in primary application instance"), NULL },
     { "volume", 0, 0, G_OPTION_ARG_DOUBLE, NULL, _("Audio volume to set (0 - 2.0 range)"), NULL },
     { "speed", 0, 0, G_OPTION_ARG_DOUBLE, NULL, _("Playback speed to set (0.05 - 2.0 range)"), NULL },
+    { "progression-mode", 0, 0, G_OPTION_ARG_INT, NULL, _("Initial queue progression mode (0=none, 1=consecutive, 2=repeat-item, 3=carousel, 4=shuffle)"), NULL },
     { "video-filter", 0, 0, G_OPTION_ARG_STRING, NULL, _("Video filter to use (\"none\" to disable)"), NULL },
     { "audio-filter", 0, 0, G_OPTION_ARG_STRING, NULL, _("Audio filter to use (\"none\" to disable)"), NULL },
     { "video-sink", 0, 0, G_OPTION_ARG_STRING, NULL, _("Video sink to use"), NULL },

--- a/src/bin/clapper-app/clapper-app-utils.c
+++ b/src/bin/clapper-app/clapper-app-utils.c
@@ -185,6 +185,30 @@ clapper_app_utils_files_from_string (const gchar *string, GFile ***files, gint *
   return success;
 }
 
+gboolean
+clapper_app_utils_files_from_command_line (GApplicationCommandLine *cmd_line, GFile ***files, gint *n_files)
+{
+  GSList *slist = NULL;
+  gchar **argv;
+  gint i, argc = 0;
+  gboolean success;
+
+  argv = g_application_command_line_get_arguments (cmd_line, &argc);
+
+  for (i = 1; i < argc; ++i)
+    slist = g_slist_append (slist, g_application_command_line_create_file_for_arg (cmd_line, argv[i]));
+
+  g_strfreev (argv);
+
+  if (!slist)
+    return FALSE;
+
+  success = clapper_app_utils_files_from_slist (slist, files, n_files);
+  g_slist_free_full (slist, g_object_unref);
+
+  return success;
+}
+
 static inline gboolean
 _files_from_file (GFile *file, GFile ***files, gint *n_files)
 {

--- a/src/bin/clapper-app/clapper-app-utils.c
+++ b/src/bin/clapper-app/clapper-app-utils.c
@@ -324,3 +324,29 @@ parse_overrides:
 
   g_free (stored_overrides);
 }
+
+GstElement *
+clapper_app_utils_make_element (const gchar *string)
+{
+  gchar *char_loc;
+
+  if (strcmp (string, "none") == 0)
+    return NULL;
+
+  char_loc = strchr (string, ' ');
+
+  if (char_loc) {
+    GstElement *element;
+    GError *error = NULL;
+
+    element = gst_parse_bin_from_description (string, TRUE, &error);
+    if (error) {
+      GST_ERROR ("Bin parse error: \"%s\", reason: %s", string, error->message);
+      g_error_free (error);
+    }
+
+    return element;
+  }
+
+  return gst_element_factory_make (string, NULL);
+}

--- a/src/bin/clapper-app/clapper-app-utils.h
+++ b/src/bin/clapper-app/clapper-app-utils.h
@@ -59,4 +59,7 @@ void clapper_app_utils_files_free (GFile **files);
 G_GNUC_INTERNAL
 void clapper_app_utils_iterate_plugin_feature_ranks (GSettings *settings, ClapperAppUtilsIterRanks callback, gpointer user_data);
 
+G_GNUC_INTERNAL
+GstElement * clapper_app_utils_make_element (const gchar *string);
+
 G_END_DECLS

--- a/src/bin/clapper-app/clapper-app-utils.h
+++ b/src/bin/clapper-app/clapper-app-utils.h
@@ -51,6 +51,9 @@ G_GNUC_INTERNAL
 gboolean clapper_app_utils_files_from_string (const gchar *string, GFile ***files, gint *n_files);
 
 G_GNUC_INTERNAL
+gboolean clapper_app_utils_files_from_command_line (GApplicationCommandLine *cmd_line, GFile ***files, gint *n_files);
+
+G_GNUC_INTERNAL
 gboolean clapper_app_utils_files_from_value (const GValue *value, GFile ***files, gint *n_files);
 
 G_GNUC_INTERNAL

--- a/src/bin/clapper-app/clapper-app-window.c
+++ b/src/bin/clapper-app/clapper-app-window.c
@@ -74,6 +74,8 @@ struct _ClapperAppWindow
 #define parent_class clapper_app_window_parent_class
 G_DEFINE_TYPE (ClapperAppWindow, clapper_app_window, GTK_TYPE_APPLICATION_WINDOW)
 
+static guint16 instance_count = 0;
+
 static void
 _media_item_title_changed_cb (ClapperMediaItem *item,
     GParamSpec *pspec G_GNUC_UNUSED, ClapperAppWindow *self)
@@ -1008,14 +1010,18 @@ clapper_app_window_constructed (GObject *object)
 #if (CLAPPER_HAVE_MPRIS || CLAPPER_HAVE_SERVER || CLAPPER_HAVE_DISCOVERER)
   ClapperFeature *feature = NULL;
 #endif
+#if CLAPPER_HAVE_MPRIS
+  gchar mpris_name[45];
+  g_snprintf (mpris_name, sizeof (mpris_name),
+      "org.mpris.MediaPlayer2.Clapper.instance%" G_GUINT16_FORMAT, instance_count++);
+#endif
 
   self->settings = g_settings_new (CLAPPER_APP_ID);
   self->last_volume = PERCENTAGE_ROUND (g_settings_get_double (self->settings, "volume"));
 
 #if CLAPPER_HAVE_MPRIS
   feature = CLAPPER_FEATURE (clapper_mpris_new (
-      "org.mpris.MediaPlayer2.Clapper",
-      "Clapper", CLAPPER_APP_ID));
+      mpris_name, CLAPPER_APP_NAME, CLAPPER_APP_ID));
   clapper_mpris_set_queue_controllable (CLAPPER_MPRIS (feature), TRUE);
   clapper_player_add_feature (player, feature);
   gst_object_unref (feature);

--- a/src/bin/clapper-app/data/applications/com.github.rafostar.Clapper.desktop
+++ b/src/bin/clapper-app/data/applications/com.github.rafostar.Clapper.desktop
@@ -14,3 +14,8 @@ Type=Application
 Keywords=Video;Movie;Film;Clip;Series;Player;Playlist;DVD;TV;Disc;Album;Music;GNOME;Clapper;
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;
+Actions=new-window;
+
+[Desktop Action new-window]
+Name=New Window
+Exec=clapper --new-window

--- a/src/bin/clapper-app/po/POTFILES
+++ b/src/bin/clapper-app/po/POTFILES
@@ -10,6 +10,7 @@ src/bin/clapper-app/ui/clapper-app-uri-dialog.ui
 src/bin/clapper-app/ui/clapper-app-video-stream-list-item.ui
 
 src/bin/clapper-app/clapper-app-about-window.c
+src/bin/clapper-app/clapper-app-application.c
 src/bin/clapper-app/clapper-app-info-window.c
 src/bin/clapper-app/clapper-app-list-item-utils.c
 src/bin/clapper-app/clapper-app-preferences-window.c


### PR DESCRIPTION
- [x] allow setting GStreamer elements (audio/video filters and sinks)
- [x] set volume
- [x] set speed
- [x] enqueue media to primary app instance
- [x] create new application window
- [x] set queue progression mode
- [x] start fullscreen
- [x] fix remaining options description in --help

Closes #294
Closes #112 
Partially implements #76 