### PR TITLE
Support MS Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,89 @@
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+name: "Windows"
+jobs:
+  windows:
+    name: "Windows"
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [x86_64]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup MSYS2
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: |-
+          mingw-w64-${{ matrix.arch }}-meson
+          mingw-w64-${{ matrix.arch }}-gcc
+          mingw-w64-${{ matrix.arch }}-glib2
+          mingw-w64-${{ matrix.arch }}-gstreamer
+          mingw-w64-${{ matrix.arch }}-gst-plugins-base
+          mingw-w64-${{ matrix.arch }}-gst-plugins-good
+          mingw-w64-${{ matrix.arch }}-gst-plugins-bad
+          mingw-w64-${{ matrix.arch }}-gst-plugins-ugly
+          mingw-w64-${{ matrix.arch }}-gst-libav
+          mingw-w64-${{ matrix.arch }}-libsoup3
+          mingw-w64-${{ matrix.arch }}-libmicrodns
+          mingw-w64-${{ matrix.arch }}-gtk4
+          mingw-w64-${{ matrix.arch }}-libadwaita
+    - name: Prepare
+      run: |
+        BUILD_PREFIX="$GITHUB_WORKSPACE/clapper-win-${{ matrix.arch }}"
+
+        mkdir -p $BUILD_PREFIX/bin
+        cp /mingw64/bin/gdbus.exe $BUILD_PREFIX/bin/
+        cp /mingw64/bin/gst-inspect-1.0.exe $BUILD_PREFIX/bin/
+
+        mkdir -p $BUILD_PREFIX/lib
+        cp -r /mingw64/lib/gio $BUILD_PREFIX/lib/
+        cp -r /mingw64/lib/gstreamer-1.0 $BUILD_PREFIX/lib/
+        cp -r /mingw64/lib/gdk-pixbuf-2.0 $BUILD_PREFIX/lib/
+
+        mkdir -p $BUILD_PREFIX/share/glib-2.0/schemas
+        cp -r /mingw64/share/glib-2.0/schemas/*.xml $BUILD_PREFIX/share/glib-2.0/schemas/
+        cp -r /mingw64/share/icons $BUILD_PREFIX/share/
+
+        mkdir -p $BUILD_PREFIX/share/xml/iso-codes
+        cp /mingw64/share/xml/iso-codes/iso_639.xml $BUILD_PREFIX/share/xml/iso-codes/
+
+        cd "$BUILD_PREFIX/lib/gstreamer-1.0"
+        rm -f \
+            libgstadpcmenc.dll libgstamfcodec.dll libgstdvbsubenc.dll libgstencoding.dll \
+            libgstfrei0r.dll libgstinter.dll libgstlame.dll libgstldac.dll libgstmpeg2enc.dll \
+            libgstmpegpsmux.dll libgstmpegtsmux.dll libgstmplex.dll libgstrealmedia.dll \
+            libgstsubenc.dll libgstsvtav1.dll libgstsvthevcenc.dll libgsttwolame.dll \
+            libgstvoamrwbenc.dll libgstwavenc.dll libgstx264.dll libgstx265.dll \
+            libgstxingmux.dll libgsty4menc.dll libgstzbar.dll
+    - name: Build
+      run: |
+        meson setup builddir --prefix=$GITHUB_WORKSPACE/clapper-win-${{ matrix.arch }}
+        cd builddir
+        meson compile
+        meson install
+    - name: Package
+      run: |
+        BUILD_PREFIX="$GITHUB_WORKSPACE/clapper-win-${{ matrix.arch }}"
+
+        ldd $BUILD_PREFIX/bin/clapper.exe | grep '\/mingw.*\.dll' -o | xargs -I{} cp -n "{}" $BUILD_PREFIX/bin
+        find $BUILD_PREFIX/lib/clapper-0.0/ -name '*\.dll' -type f -exec ldd "{}" \; | grep '\/mingw.*\.dll' -o | xargs -I{} cp -n "{}" $BUILD_PREFIX/bin
+        find $BUILD_PREFIX/lib/gstreamer-1.0/ -name '*\.dll' -type f -exec ldd "{}" \; | grep '\/mingw.*\.dll' -o | xargs -I{} cp -n "{}" $BUILD_PREFIX/bin
+        find $BUILD_PREFIX/lib/gio/ -name '*\.dll' -type f -exec ldd "{}" \; | grep '\/mingw.*\.dll' -o | xargs -I{} cp -n "{}" $BUILD_PREFIX/bin
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: clapper-win-${{ matrix.arch }}
+        path: clapper-win-${{ matrix.arch }}
+        if-no-files-found: error

--- a/src/bin/clapper-app/clapper-app-file-dialog.c
+++ b/src/bin/clapper-app/clapper-app-file-dialog.c
@@ -80,8 +80,15 @@ _dialog_add_mime_types (GtkFileDialog *dialog, const gchar *filter_name,
   GtkFileFilter *filter = gtk_file_filter_new ();
   guint i;
 
-  for (i = 0; mime_types[i]; ++i)
+  /* XXX: Windows does not support mime-types file
+   * filters, so use file extensions instead */
+  for (i = 0; mime_types[i]; ++i) {
+#ifndef G_OS_WIN32
     gtk_file_filter_add_mime_type (filter, mime_types[i]);
+#else
+    gtk_file_filter_add_suffix (filter, mime_types[i]);
+#endif
+  }
 
   gtk_file_filter_set_name (filter, filter_name);
   g_list_store_append (filters, filter);
@@ -99,7 +106,11 @@ clapper_app_file_dialog_open_files (GtkApplication *gtk_app)
   GtkFileDialog *dialog = gtk_file_dialog_new ();
 
   _dialog_add_mime_types (dialog, "Media Files",
+#ifndef G_OS_WIN32
       clapper_app_utils_get_mime_types ());
+#else
+      clapper_app_utils_get_extensions ());
+#endif
 
   gtk_file_dialog_set_modal (dialog, TRUE);
   gtk_file_dialog_set_title (dialog, "Add Files");
@@ -118,7 +129,11 @@ clapper_app_file_dialog_open_subtitles (GtkApplication *gtk_app, ClapperMediaIte
   GtkFileDialog *dialog = gtk_file_dialog_new ();
 
   _dialog_add_mime_types (dialog, "Subtitles",
+#ifndef G_OS_WIN32
       clapper_app_utils_get_subtitles_mime_types ());
+#else
+      clapper_app_utils_get_subtitles_extensions ());
+#endif
 
   gtk_file_dialog_set_modal (dialog, TRUE);
   gtk_file_dialog_set_title (dialog, "Open Subtitles");

--- a/src/bin/clapper-app/clapper-app-types.c
+++ b/src/bin/clapper-app/clapper-app-types.c
@@ -1,0 +1,42 @@
+/* Clapper Application
+ * Copyright (C) 2024 Rafał Dzięgiel <rafostar.github@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "clapper-app-types.h"
+
+#include "clapper-app-headerbar.h"
+#include "clapper-app-media-item-box.h"
+#include "clapper-app-property-row.h"
+#include "clapper-app-queue-list.h"
+#include "clapper-app-queue-progression-model.h"
+#include "clapper-app-window-state-buttons.h"
+
+/*
+ * clapper_app_types_init:
+ *
+ * Ensure private types that appear in UI files in order for
+ * GtkBuilder to be able to find them when building templates.
+ */
+inline void
+clapper_app_types_init (void)
+{
+  g_type_ensure (CLAPPER_APP_TYPE_HEADERBAR);
+  g_type_ensure (CLAPPER_APP_TYPE_MEDIA_ITEM_BOX);
+  g_type_ensure (CLAPPER_APP_TYPE_PROPERTY_ROW);
+  g_type_ensure (CLAPPER_APP_TYPE_QUEUE_LIST);
+  g_type_ensure (CLAPPER_APP_TYPE_QUEUE_PROGRESSION_MODEL);
+  g_type_ensure (CLAPPER_APP_TYPE_WINDOW_STATE_BUTTONS);
+}

--- a/src/bin/clapper-app/clapper-app-types.h
+++ b/src/bin/clapper-app/clapper-app-types.h
@@ -1,0 +1,27 @@
+/* Clapper Application
+ * Copyright (C) 2024 Rafał Dzięgiel <rafostar.github@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+G_GNUC_INTERNAL
+void clapper_app_types_init (void);
+
+G_END_DECLS

--- a/src/bin/clapper-app/clapper-app-utils.c
+++ b/src/bin/clapper-app/clapper-app-utils.c
@@ -23,6 +23,30 @@
 #include "clapper-app-utils.h"
 #include "clapper-app-media-item-box.h"
 
+/* Useful only on Windows */
+#ifdef G_OS_WIN32
+const gchar *const *
+clapper_app_utils_get_extensions (void)
+{
+  static const gchar *const all_extensions[] = {
+    "avi", "claps", "m2ts", "mkv", "mov",
+    "mp4", "webm", "wmv", NULL
+  };
+
+  return all_extensions;
+}
+
+const gchar *const *
+clapper_app_utils_get_subtitles_extensions (void)
+{
+  static const gchar *const subs_extensions[] = {
+    "srt", "vtt", NULL
+  };
+
+  return subs_extensions;
+}
+#endif
+
 const gchar *const *
 clapper_app_utils_get_mime_types (void)
 {

--- a/src/bin/clapper-app/clapper-app-utils.h
+++ b/src/bin/clapper-app/clapper-app-utils.h
@@ -26,6 +26,14 @@ G_BEGIN_DECLS
 
 typedef void (* ClapperAppUtilsIterRanks) (const gchar *feature_name, GstRank rank, gboolean from_env, gpointer user_data);
 
+#ifdef G_OS_WIN32
+G_GNUC_INTERNAL
+const gchar *const * clapper_app_utils_get_extensions (void);
+
+G_GNUC_INTERNAL
+const gchar *const * clapper_app_utils_get_subtitles_extensions (void);
+#endif
+
 G_GNUC_INTERNAL
 const gchar *const * clapper_app_utils_get_mime_types (void);
 

--- a/src/bin/clapper-app/clapper-app-window.c
+++ b/src/bin/clapper-app/clapper-app-window.c
@@ -86,7 +86,9 @@ typedef struct
   gint64 last_tick;
 } ClapperAppWindowResizeData;
 
+#if CLAPPER_HAVE_MPRIS
 static guint16 instance_count = 0;
+#endif
 
 static inline GQuark
 clapper_app_window_extra_options_get_quark (void)

--- a/src/bin/clapper-app/data/meson.build
+++ b/src/bin/clapper-app/data/meson.build
@@ -25,14 +25,12 @@ endif
 install_subdir('icons',
   install_dir: join_paths(prefix, datadir)
 )
-install_subdir('mime',
-  install_dir: join_paths(prefix, datadir)
-)
 install_subdir('metainfo',
   install_dir: join_paths(prefix, datadir)
 )
 
 is_linux = ['linux'].contains(host_machine.system())
+is_windows = ['windows'].contains(host_machine.system())
 
 if is_linux
   install_subdir('applications',
@@ -41,11 +39,17 @@ if is_linux
   subdir('dbus-1')
 endif
 
+if not is_windows
+  install_subdir('mime',
+    install_dir: join_paths(prefix, datadir)
+  )
+endif
+
 subdir('glib-2.0/schemas')
 
 gnome.post_install(
   glib_compile_schemas: true,
   gtk_update_icon_cache: true,
   update_desktop_database: is_linux,
-  update_mime_database: true,
+  update_mime_database: not is_windows,
 )

--- a/src/bin/clapper-app/data/meson.build
+++ b/src/bin/clapper-app/data/meson.build
@@ -1,7 +1,3 @@
-if not ['linux'].contains(host_machine.system())
-  subdir_done()
-endif
-
 appstream_util = find_program('appstream-util', required: false)
 if appstream_util.found()
   test('Validate appstream file',
@@ -32,19 +28,24 @@ install_subdir('icons',
 install_subdir('mime',
   install_dir: join_paths(prefix, datadir)
 )
-install_subdir('applications',
-  install_dir: join_paths(prefix, datadir)
-)
 install_subdir('metainfo',
   install_dir: join_paths(prefix, datadir)
 )
 
+is_linux = ['linux'].contains(host_machine.system())
+
+if is_linux
+  install_subdir('applications',
+    install_dir: join_paths(prefix, datadir)
+  )
+  subdir('dbus-1')
+endif
+
 subdir('glib-2.0/schemas')
-subdir('dbus-1')
 
 gnome.post_install(
   glib_compile_schemas: true,
   gtk_update_icon_cache: true,
-  update_desktop_database: true,
+  update_desktop_database: is_linux,
   update_mime_database: true,
 )

--- a/src/bin/clapper-app/main.c
+++ b/src/bin/clapper-app/main.c
@@ -25,6 +25,7 @@
 #include <clapper/clapper.h>
 
 #include "clapper-app-application.h"
+#include "clapper-app-types.h"
 
 gint
 main (gint argc, gchar **argv)
@@ -45,6 +46,8 @@ main (gint argc, gchar **argv)
   clapper_init (&argc, &argv);
   gtk_init ();
   adw_init ();
+
+  clapper_app_types_init ();
 
   g_set_application_name ("Clapper");
 

--- a/src/bin/clapper-app/meson.build
+++ b/src/bin/clapper-app/meson.build
@@ -88,5 +88,18 @@ executable(
   c_args: clapperapp_c_args,
   install: true,
   install_dir: bindir,
+  win_subsystem: 'windows',
 )
+if ['windows'].contains(host_machine.system())
+  executable(
+    meson.project_name() + '-console',
+    clapperapp_sources,
+    dependencies: clapperapp_deps,
+    include_directories: clapperapp_conf_inc,
+    c_args: clapperapp_c_args,
+    install: true,
+    install_dir: bindir,
+    win_subsystem: 'console',
+  )
+endif
 build_clapperapp = true

--- a/src/bin/clapper-app/meson.build
+++ b/src/bin/clapper-app/meson.build
@@ -67,6 +67,7 @@ clapperapp_sources = [
   'clapper-app-queue-progression-item.c',
   'clapper-app-queue-progression-model.c',
   'clapper-app-queue-selection.c',
+  'clapper-app-types.c',
   'clapper-app-uri-dialog.c',
   'clapper-app-utils.c',
   'clapper-app-window.c',

--- a/src/lib/clapper-gtk/clapper-gtk-billboard.h
+++ b/src/lib/clapper-gtk/clapper-gtk-billboard.h
@@ -27,6 +27,7 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
 #include <clapper-gtk/clapper-gtk-container.h>
 
 G_BEGIN_DECLS
@@ -34,18 +35,25 @@ G_BEGIN_DECLS
 #define CLAPPER_GTK_TYPE_BILLBOARD (clapper_gtk_billboard_get_type())
 #define CLAPPER_GTK_BILLBOARD_CAST(obj) ((ClapperGtkBillboard *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkBillboard, clapper_gtk_billboard, CLAPPER_GTK, BILLBOARD, ClapperGtkContainer)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_billboard_new (void);
 
+CLAPPER_GTK_API
 void clapper_gtk_billboard_post_message (ClapperGtkBillboard *billboard, const gchar *icon_name, const gchar *message);
 
+CLAPPER_GTK_API
 void clapper_gtk_billboard_pin_message (ClapperGtkBillboard *billboard, const gchar *icon_name, const gchar *message);
 
+CLAPPER_GTK_API
 void clapper_gtk_billboard_unpin_pinned_message (ClapperGtkBillboard *billboard);
 
+CLAPPER_GTK_API
 void clapper_gtk_billboard_announce_volume (ClapperGtkBillboard *billboard);
 
+CLAPPER_GTK_API
 void clapper_gtk_billboard_announce_speed (ClapperGtkBillboard *billboard);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-container.h
+++ b/src/lib/clapper-gtk/clapper-gtk-container.h
@@ -27,11 +27,14 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
+
 G_BEGIN_DECLS
 
 #define CLAPPER_GTK_TYPE_CONTAINER (clapper_gtk_container_get_type())
 #define CLAPPER_GTK_CONTAINER_CAST(obj) ((ClapperGtkContainer *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_DERIVABLE_TYPE (ClapperGtkContainer, clapper_gtk_container, CLAPPER_GTK, CONTAINER, GtkWidget)
 
 struct _ClapperGtkContainerClass
@@ -42,26 +45,37 @@ struct _ClapperGtkContainerClass
   gpointer padding[4];
 };
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_container_new (void);
 
+CLAPPER_GTK_API
 void clapper_gtk_container_set_child (ClapperGtkContainer *container, GtkWidget *child);
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_container_get_child (ClapperGtkContainer *container);
 
+CLAPPER_GTK_API
 void clapper_gtk_container_set_width_target (ClapperGtkContainer *container, gint width);
 
+CLAPPER_GTK_API
 gint clapper_gtk_container_get_width_target (ClapperGtkContainer *container);
 
+CLAPPER_GTK_API
 void clapper_gtk_container_set_height_target (ClapperGtkContainer *container, gint height);
 
+CLAPPER_GTK_API
 gint clapper_gtk_container_get_height_target (ClapperGtkContainer *container);
 
+CLAPPER_GTK_API
 void clapper_gtk_container_set_adaptive_width (ClapperGtkContainer *container, gint width);
 
+CLAPPER_GTK_API
 gint clapper_gtk_container_get_adaptive_width (ClapperGtkContainer *container);
 
+CLAPPER_GTK_API
 void clapper_gtk_container_set_adaptive_height (ClapperGtkContainer *container, gint height);
 
+CLAPPER_GTK_API
 gint clapper_gtk_container_get_adaptive_height (ClapperGtkContainer *container);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-extra-menu-button.c
+++ b/src/lib/clapper-gtk/clapper-gtk-extra-menu-button.c
@@ -30,6 +30,7 @@
 #include <clapper/clapper.h>
 
 #include "clapper-gtk-extra-menu-button.h"
+#include "clapper-gtk-stream-check-button-private.h"
 #include "clapper-gtk-utils-private.h"
 
 #define PERCENTAGE_ROUND(a) (round ((gdouble) a / 0.01) * 0.01)
@@ -452,6 +453,9 @@ clapper_gtk_extra_menu_button_init (ClapperGtkExtraMenuButton *self)
     { "subtitle-stream-enabled", NULL, NULL, "true", change_subtitle_stream_enabled },
     { "open-subtitle-stream", open_subtitle_stream, NULL, NULL, NULL },
   };
+
+  /* Ensure private types */
+  g_type_ensure (CLAPPER_GTK_TYPE_STREAM_CHECK_BUTTON);
 
   gtk_widget_init_template (GTK_WIDGET (self));
 

--- a/src/lib/clapper-gtk/clapper-gtk-extra-menu-button.h
+++ b/src/lib/clapper-gtk/clapper-gtk-extra-menu-button.h
@@ -27,25 +27,35 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
+
 G_BEGIN_DECLS
 
 #define CLAPPER_GTK_TYPE_EXTRA_MENU_BUTTON (clapper_gtk_extra_menu_button_get_type())
 #define CLAPPER_GTK_EXTRA_MENU_BUTTON_CAST(obj) ((ClapperGtkExtraMenuButton *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkExtraMenuButton, clapper_gtk_extra_menu_button, CLAPPER_GTK, EXTRA_MENU_BUTTON, GtkWidget)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_extra_menu_button_new (void);
 
+CLAPPER_GTK_API
 void clapper_gtk_extra_menu_button_set_volume_visible (ClapperGtkExtraMenuButton *button, gboolean visible);
 
+CLAPPER_GTK_API
 gboolean clapper_gtk_extra_menu_button_get_volume_visible (ClapperGtkExtraMenuButton *button);
 
+CLAPPER_GTK_API
 void clapper_gtk_extra_menu_button_set_speed_visible (ClapperGtkExtraMenuButton *button, gboolean visible);
 
+CLAPPER_GTK_API
 gboolean clapper_gtk_extra_menu_button_get_speed_visible (ClapperGtkExtraMenuButton *button);
 
+CLAPPER_GTK_API
 void clapper_gtk_extra_menu_button_set_can_open_subtitles (ClapperGtkExtraMenuButton *button, gboolean allowed);
 
+CLAPPER_GTK_API
 gboolean clapper_gtk_extra_menu_button_get_can_open_subtitles (ClapperGtkExtraMenuButton *button);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-lead-container.h
+++ b/src/lib/clapper-gtk/clapper-gtk-lead-container.h
@@ -27,6 +27,7 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
 #include <clapper-gtk/clapper-gtk-enums.h>
 #include <clapper-gtk/clapper-gtk-container.h>
 
@@ -35,6 +36,7 @@ G_BEGIN_DECLS
 #define CLAPPER_GTK_TYPE_LEAD_CONTAINER (clapper_gtk_lead_container_get_type())
 #define CLAPPER_GTK_LEAD_CONTAINER_CAST(obj) ((ClapperGtkLeadContainer *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_DERIVABLE_TYPE (ClapperGtkLeadContainer, clapper_gtk_lead_container, CLAPPER_GTK, LEAD_CONTAINER, ClapperGtkContainer)
 
 struct _ClapperGtkLeadContainerClass
@@ -45,14 +47,19 @@ struct _ClapperGtkLeadContainerClass
   gpointer padding[4];
 };
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_lead_container_new (void);
 
+CLAPPER_GTK_API
 void clapper_gtk_lead_container_set_leading (ClapperGtkLeadContainer *lead_container, gboolean leading);
 
+CLAPPER_GTK_API
 gboolean clapper_gtk_lead_container_get_leading (ClapperGtkLeadContainer *lead_container);
 
+CLAPPER_GTK_API
 void clapper_gtk_lead_container_set_blocked_actions (ClapperGtkLeadContainer *lead_container, ClapperGtkVideoActionMask actions);
 
+CLAPPER_GTK_API
 ClapperGtkVideoActionMask clapper_gtk_lead_container_get_blocked_actions (ClapperGtkLeadContainer *lead_container);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-next-item-button.h
+++ b/src/lib/clapper-gtk/clapper-gtk-next-item-button.h
@@ -27,13 +27,17 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
+
 G_BEGIN_DECLS
 
 #define CLAPPER_GTK_TYPE_NEXT_ITEM_BUTTON (clapper_gtk_next_item_button_get_type())
 #define CLAPPER_GTK_NEXT_ITEM_BUTTON_CAST(obj) ((ClapperGtkNextItemButton *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkNextItemButton, clapper_gtk_next_item_button, CLAPPER_GTK, NEXT_ITEM_BUTTON, GtkButton)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_next_item_button_new (void);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-previous-item-button.h
+++ b/src/lib/clapper-gtk/clapper-gtk-previous-item-button.h
@@ -27,13 +27,17 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
+
 G_BEGIN_DECLS
 
 #define CLAPPER_GTK_TYPE_PREVIOUS_ITEM_BUTTON (clapper_gtk_previous_item_button_get_type())
 #define CLAPPER_GTK_PREVIOUS_ITEM_BUTTON_CAST(obj) ((ClapperGtkPreviousItemButton *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkPreviousItemButton, clapper_gtk_previous_item_button, CLAPPER_GTK, PREVIOUS_ITEM_BUTTON, GtkButton)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_previous_item_button_new (void);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-seek-bar.h
+++ b/src/lib/clapper-gtk/clapper-gtk-seek-bar.h
@@ -28,21 +28,29 @@
 #include <gtk/gtk.h>
 #include <clapper/clapper.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
+
 G_BEGIN_DECLS
 
 #define CLAPPER_GTK_TYPE_SEEK_BAR (clapper_gtk_seek_bar_get_type())
 #define CLAPPER_GTK_SEEK_BAR_CAST(obj) ((ClapperGtkSeekBar *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkSeekBar, clapper_gtk_seek_bar, CLAPPER_GTK, SEEK_BAR, GtkWidget)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_seek_bar_new (void);
 
+CLAPPER_GTK_API
 void clapper_gtk_seek_bar_set_reveal_labels (ClapperGtkSeekBar *seek_bar, gboolean reveal);
 
+CLAPPER_GTK_API
 gboolean clapper_gtk_seek_bar_get_reveal_labels (ClapperGtkSeekBar *seek_bar);
 
+CLAPPER_GTK_API
 void clapper_gtk_seek_bar_set_seek_method (ClapperGtkSeekBar *seek_bar, ClapperPlayerSeekMethod method);
 
+CLAPPER_GTK_API
 ClapperPlayerSeekMethod clapper_gtk_seek_bar_get_seek_method (ClapperGtkSeekBar *seek_bar);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-simple-controls.h
+++ b/src/lib/clapper-gtk/clapper-gtk-simple-controls.h
@@ -26,6 +26,8 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
+
+#include <clapper-gtk/clapper-gtk-visibility.h>
 #include <clapper-gtk/clapper-gtk-container.h>
 #include <clapper-gtk/clapper-gtk-extra-menu-button.h>
 
@@ -34,18 +36,25 @@ G_BEGIN_DECLS
 #define CLAPPER_GTK_TYPE_SIMPLE_CONTROLS (clapper_gtk_simple_controls_get_type())
 #define CLAPPER_GTK_SIMPLE_CONTROLS_CAST(obj) ((ClapperGtkSimpleControls *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkSimpleControls, clapper_gtk_simple_controls, CLAPPER_GTK, SIMPLE_CONTROLS, ClapperGtkContainer)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_simple_controls_new (void);
 
+CLAPPER_GTK_API
 void clapper_gtk_simple_controls_set_fullscreenable (ClapperGtkSimpleControls *controls, gboolean fullscreenable);
 
+CLAPPER_GTK_API
 gboolean clapper_gtk_simple_controls_get_fullscreenable (ClapperGtkSimpleControls *controls);
 
+CLAPPER_GTK_API
 void clapper_gtk_simple_controls_set_seek_method (ClapperGtkSimpleControls *controls, ClapperPlayerSeekMethod method);
 
+CLAPPER_GTK_API
 ClapperPlayerSeekMethod clapper_gtk_simple_controls_get_seek_method (ClapperGtkSimpleControls *controls);
 
+CLAPPER_GTK_API
 ClapperGtkExtraMenuButton * clapper_gtk_simple_controls_get_extra_menu_button (ClapperGtkSimpleControls *controls);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-title-header.h
+++ b/src/lib/clapper-gtk/clapper-gtk-title-header.h
@@ -26,6 +26,8 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
+
+#include <clapper-gtk/clapper-gtk-visibility.h>
 #include <clapper-gtk/clapper-gtk-lead-container.h>
 
 G_BEGIN_DECLS
@@ -33,14 +35,19 @@ G_BEGIN_DECLS
 #define CLAPPER_GTK_TYPE_TITLE_HEADER (clapper_gtk_title_header_get_type())
 #define CLAPPER_GTK_TITLE_HEADER_CAST(obj) ((ClapperGtkTitleHeader *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkTitleHeader, clapper_gtk_title_header, CLAPPER_GTK, TITLE_HEADER, ClapperGtkLeadContainer)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_title_header_new (void);
 
+CLAPPER_GTK_API
 const gchar * clapper_gtk_title_header_get_current_title (ClapperGtkTitleHeader *header);
 
+CLAPPER_GTK_API
 void clapper_gtk_title_header_set_fallback_to_uri (ClapperGtkTitleHeader *header, gboolean enabled);
 
+CLAPPER_GTK_API
 gboolean clapper_gtk_title_header_get_fallback_to_uri (ClapperGtkTitleHeader *header);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-title-label.h
+++ b/src/lib/clapper-gtk/clapper-gtk-title-label.h
@@ -28,23 +28,32 @@
 #include <gtk/gtk.h>
 #include <clapper/clapper.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
+
 G_BEGIN_DECLS
 
 #define CLAPPER_GTK_TYPE_TITLE_LABEL (clapper_gtk_title_label_get_type())
 #define CLAPPER_GTK_TITLE_LABEL_CAST(obj) ((ClapperGtkTitleLabel *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkTitleLabel, clapper_gtk_title_label, CLAPPER_GTK, TITLE_LABEL, GtkWidget)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_title_label_new (void);
 
+CLAPPER_GTK_API
 void clapper_gtk_title_label_set_media_item (ClapperGtkTitleLabel *label, ClapperMediaItem *item);
 
+CLAPPER_GTK_API
 ClapperMediaItem * clapper_gtk_title_label_get_media_item (ClapperGtkTitleLabel *label);
 
+CLAPPER_GTK_API
 const gchar * clapper_gtk_title_label_get_current_title (ClapperGtkTitleLabel *label);
 
+CLAPPER_GTK_API
 void clapper_gtk_title_label_set_fallback_to_uri (ClapperGtkTitleLabel *label, gboolean enabled);
 
+CLAPPER_GTK_API
 gboolean clapper_gtk_title_label_get_fallback_to_uri (ClapperGtkTitleLabel *label);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-toggle-fullscreen-button.h
+++ b/src/lib/clapper-gtk/clapper-gtk-toggle-fullscreen-button.h
@@ -27,13 +27,17 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
+
 G_BEGIN_DECLS
 
 #define CLAPPER_GTK_TYPE_TOGGLE_FULLSCREEN_BUTTON (clapper_gtk_toggle_fullscreen_button_get_type())
 #define CLAPPER_GTK_TOGGLE_FULLSCREEN_BUTTON_CAST(obj) ((ClapperGtkToggleFullscreenButton *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkToggleFullscreenButton, clapper_gtk_toggle_fullscreen_button, CLAPPER_GTK, TOGGLE_FULLSCREEN_BUTTON, GtkButton)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_toggle_fullscreen_button_new (void);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-toggle-play-button.h
+++ b/src/lib/clapper-gtk/clapper-gtk-toggle-play-button.h
@@ -27,13 +27,17 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
+
 G_BEGIN_DECLS
 
 #define CLAPPER_GTK_TYPE_TOGGLE_PLAY_BUTTON (clapper_gtk_toggle_play_button_get_type())
 #define CLAPPER_GTK_TOGGLE_PLAY_BUTTON_CAST(obj) ((ClapperGtkTogglePlayButton *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkTogglePlayButton, clapper_gtk_toggle_play_button, CLAPPER_GTK, TOGGLE_PLAY_BUTTON, GtkButton)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_toggle_play_button_new (void);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-utils.h
+++ b/src/lib/clapper-gtk/clapper-gtk-utils.h
@@ -27,8 +27,11 @@
 #include <gtk/gtk.h>
 #include <clapper/clapper.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
+
 G_BEGIN_DECLS
 
+CLAPPER_GTK_API
 ClapperPlayer * clapper_gtk_get_player_from_ancestor (GtkWidget *widget);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/clapper-gtk-video.c
+++ b/src/lib/clapper-gtk/clapper-gtk-video.c
@@ -1384,6 +1384,10 @@ clapper_gtk_video_init (ClapperGtkVideo *self)
   self->touch_fade_delay = DEFAULT_TOUCH_FADE_DELAY;
   self->auto_inhibit = DEFAULT_AUTO_INHIBIT;
 
+  /* Ensure private types */
+  g_type_ensure (CLAPPER_GTK_TYPE_STATUS);
+  g_type_ensure (CLAPPER_GTK_TYPE_BUFFERING_ANIMATION);
+
   gtk_widget_init_template (GTK_WIDGET (self));
 
   gtk_gesture_group (self->touch_gesture, self->click_gesture);

--- a/src/lib/clapper-gtk/clapper-gtk-video.h
+++ b/src/lib/clapper-gtk/clapper-gtk-video.h
@@ -28,33 +28,47 @@
 #include <gtk/gtk.h>
 #include <clapper/clapper.h>
 
+#include <clapper-gtk/clapper-gtk-visibility.h>
+
 G_BEGIN_DECLS
 
 #define CLAPPER_GTK_TYPE_VIDEO (clapper_gtk_video_get_type())
 #define CLAPPER_GTK_VIDEO_CAST(obj) ((ClapperGtkVideo *)(obj))
 
+CLAPPER_GTK_API
 G_DECLARE_FINAL_TYPE (ClapperGtkVideo, clapper_gtk_video, CLAPPER_GTK, VIDEO, GtkWidget)
 
+CLAPPER_GTK_API
 GtkWidget * clapper_gtk_video_new (void);
 
+CLAPPER_GTK_API
 void clapper_gtk_video_add_overlay (ClapperGtkVideo *video, GtkWidget *widget);
 
+CLAPPER_GTK_API
 void clapper_gtk_video_add_fading_overlay (ClapperGtkVideo *video, GtkWidget *widget);
 
+CLAPPER_GTK_API
 ClapperPlayer * clapper_gtk_video_get_player (ClapperGtkVideo *video);
 
+CLAPPER_GTK_API
 void clapper_gtk_video_set_fade_delay (ClapperGtkVideo *video, guint delay);
 
+CLAPPER_GTK_API
 guint clapper_gtk_video_get_fade_delay (ClapperGtkVideo *video);
 
+CLAPPER_GTK_API
 void clapper_gtk_video_set_touch_fade_delay (ClapperGtkVideo *video, guint delay);
 
+CLAPPER_GTK_API
 guint clapper_gtk_video_get_touch_fade_delay (ClapperGtkVideo *video);
 
+CLAPPER_GTK_API
 void clapper_gtk_video_set_auto_inhibit (ClapperGtkVideo *video, gboolean inhibit);
 
+CLAPPER_GTK_API
 gboolean clapper_gtk_video_get_auto_inhibit (ClapperGtkVideo *video);
 
+CLAPPER_GTK_API
 gboolean clapper_gtk_video_get_inhibited (ClapperGtkVideo *video);
 
 G_END_DECLS

--- a/src/lib/clapper-gtk/meson.build
+++ b/src/lib/clapper-gtk/meson.build
@@ -39,6 +39,19 @@ configure_file(
   configuration: config_h,
 )
 
+visibility_conf = configuration_data()
+
+visibility_conf.set(
+  'CLAPPER_API',
+  'CLAPPER_GTK',
+)
+
+clappergtk_visibility_header = configure_file(
+  input: '../shared/clapper-api-visibility.h.in',
+  output: 'clapper-gtk-visibility.h',
+  configuration: visibility_conf,
+)
+
 version_conf = configuration_data()
 
 version_conf.set(
@@ -93,6 +106,7 @@ clappergtk_headers = [
   'clapper-gtk-utils.h',
   'clapper-gtk-video.h',
   clappergtk_version_header,
+  clappergtk_visibility_header,
 ]
 clappergtk_sources = [
   'clapper-gtk-billboard.c',
@@ -122,11 +136,17 @@ clappergtk_c_args = [
   '-DGST_USE_UNSTABLE_API',
 ]
 
+if get_option('default_library') == 'static'
+  clappergtk_c_args += ['-DCLAPPER_GTK_STATIC_COMPILATION']
+endif
+
 clappergtk_headers_dir = join_paths(includedir, clapper_api_name, 'clapper-gtk')
 
 clappergtk_enums = gnome.mkenums_simple(
   'clapper-gtk-enum-types',
   sources: clappergtk_headers,
+  decorator: 'CLAPPER_GTK_API',
+  header_prefix: '#include <clapper-gtk/clapper-gtk-visibility.h>',
   identifier_prefix: 'ClapperGtk',
   symbol_prefix: 'clapper_gtk',
   install_header: true,
@@ -215,6 +235,7 @@ clappergtk_dep = declare_dependency(
   include_directories: clappergtk_conf_inc,
   dependencies: clappergtk_deps,
   sources: [
+    clappergtk_visibility_header,
     clappergtk_version_header,
     clappergtk_enums[1],
   ],

--- a/src/lib/clapper/clapper-audio-stream.h
+++ b/src/lib/clapper/clapper-audio-stream.h
@@ -25,6 +25,8 @@
 
 #include <glib.h>
 #include <glib-object.h>
+
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-stream.h>
 
 G_BEGIN_DECLS
@@ -32,20 +34,28 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_AUDIO_STREAM (clapper_audio_stream_get_type())
 #define CLAPPER_AUDIO_STREAM_CAST(obj) ((ClapperAudioStream *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperAudioStream, clapper_audio_stream, CLAPPER, AUDIO_STREAM, ClapperStream)
 
+CLAPPER_API
 gchar * clapper_audio_stream_get_codec (ClapperAudioStream *stream);
 
+CLAPPER_API
 guint clapper_audio_stream_get_bitrate (ClapperAudioStream *stream);
 
+CLAPPER_API
 gchar * clapper_audio_stream_get_sample_format (ClapperAudioStream *stream);
 
+CLAPPER_API
 gint clapper_audio_stream_get_sample_rate (ClapperAudioStream *stream);
 
+CLAPPER_API
 gint clapper_audio_stream_get_channels (ClapperAudioStream *stream);
 
+CLAPPER_API
 gchar * clapper_audio_stream_get_lang_code (ClapperAudioStream *stream);
 
+CLAPPER_API
 gchar * clapper_audio_stream_get_lang_name (ClapperAudioStream *stream);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-feature.h
+++ b/src/lib/clapper/clapper-feature.h
@@ -27,6 +27,8 @@
 #include <glib-object.h>
 #include <gio/gio.h>
 #include <gst/gst.h>
+
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-media-item.h>
 #include <clapper/clapper-enums.h>
 
@@ -35,6 +37,7 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_FEATURE (clapper_feature_get_type())
 #define CLAPPER_FEATURE_CAST(obj) ((ClapperFeature *)(obj))
 
+CLAPPER_API
 G_DECLARE_DERIVABLE_TYPE (ClapperFeature, clapper_feature, CLAPPER, FEATURE, GstObject)
 
 /**

--- a/src/lib/clapper/clapper-marker.h
+++ b/src/lib/clapper/clapper-marker.h
@@ -26,6 +26,8 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <gst/gst.h>
+
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-enums.h>
 
 G_BEGIN_DECLS
@@ -36,6 +38,7 @@ G_BEGIN_DECLS
 /* NOTE: #ClapperMarker are immutable objects that cannot be derived,
  * otherwise #ClapperFeaturesManager would not be able to announce media
  * item changed caused by changes within them */
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperMarker, clapper_marker, CLAPPER, MARKER, GstObject)
 
 /**
@@ -45,14 +48,19 @@ G_DECLARE_FINAL_TYPE (ClapperMarker, clapper_marker, CLAPPER, MARKER, GstObject)
  */
 #define CLAPPER_MARKER_NO_END ((gdouble) -1) // Needs a cast from int, otherwise GIR is generated incorrectly
 
+CLAPPER_API
 ClapperMarker * clapper_marker_new (ClapperMarkerType marker_type, const gchar *title, gdouble start, gdouble end);
 
+CLAPPER_API
 ClapperMarkerType clapper_marker_get_marker_type (ClapperMarker *marker);
 
+CLAPPER_API
 const gchar * clapper_marker_get_title (ClapperMarker *marker);
 
+CLAPPER_API
 gdouble clapper_marker_get_start (ClapperMarker *marker);
 
+CLAPPER_API
 gdouble clapper_marker_get_end (ClapperMarker *marker);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-media-item.h
+++ b/src/lib/clapper/clapper-media-item.h
@@ -28,6 +28,7 @@
 #include <gio/gio.h>
 #include <gst/gst.h>
 
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-timeline.h>
 
 G_BEGIN_DECLS
@@ -35,26 +36,37 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_MEDIA_ITEM (clapper_media_item_get_type())
 #define CLAPPER_MEDIA_ITEM_CAST(obj) ((ClapperMediaItem *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperMediaItem, clapper_media_item, CLAPPER, MEDIA_ITEM, GstObject)
 
+CLAPPER_API
 ClapperMediaItem * clapper_media_item_new (const gchar *uri);
 
+CLAPPER_API
 ClapperMediaItem * clapper_media_item_new_from_file (GFile *file);
 
+CLAPPER_API
 guint clapper_media_item_get_id (ClapperMediaItem *item);
 
+CLAPPER_API
 const gchar * clapper_media_item_get_uri (ClapperMediaItem *item);
 
+CLAPPER_API
 void clapper_media_item_set_suburi (ClapperMediaItem *item, const gchar *suburi);
 
+CLAPPER_API
 gchar * clapper_media_item_get_suburi (ClapperMediaItem *item);
 
+CLAPPER_API
 gchar * clapper_media_item_get_title (ClapperMediaItem *item);
 
+CLAPPER_API
 gchar * clapper_media_item_get_container_format (ClapperMediaItem *item);
 
+CLAPPER_API
 gdouble clapper_media_item_get_duration (ClapperMediaItem *item);
 
+CLAPPER_API
 ClapperTimeline * clapper_media_item_get_timeline (ClapperMediaItem *item);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-player.h
+++ b/src/lib/clapper/clapper-player.h
@@ -26,6 +26,8 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <gst/gst.h>
+
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-threaded-object.h>
 #include <clapper/clapper-queue.h>
 #include <clapper/clapper-stream-list.h>
@@ -37,100 +39,148 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_PLAYER (clapper_player_get_type())
 #define CLAPPER_PLAYER_CAST(obj) ((ClapperPlayer *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperPlayer, clapper_player, CLAPPER, PLAYER, ClapperThreadedObject)
 
+CLAPPER_API
 ClapperPlayer * clapper_player_new (void);
 
+CLAPPER_API
 ClapperQueue * clapper_player_get_queue (ClapperPlayer *player);
 
+CLAPPER_API
 ClapperStreamList * clapper_player_get_video_streams (ClapperPlayer *player);
 
+CLAPPER_API
 ClapperStreamList * clapper_player_get_audio_streams (ClapperPlayer *player);
 
+CLAPPER_API
 ClapperStreamList * clapper_player_get_subtitle_streams (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_autoplay (ClapperPlayer *player, gboolean enabled);
 
+CLAPPER_API
 gboolean clapper_player_get_autoplay (ClapperPlayer *player);
 
+CLAPPER_API
 gdouble clapper_player_get_position (ClapperPlayer *player);
 
+CLAPPER_API
 ClapperPlayerState clapper_player_get_state (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_mute (ClapperPlayer *player, gboolean mute);
 
+CLAPPER_API
 gboolean clapper_player_get_mute (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_volume (ClapperPlayer *player, gdouble volume);
 
+CLAPPER_API
 gdouble clapper_player_get_volume (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_speed (ClapperPlayer *player, gdouble speed);
 
+CLAPPER_API
 gdouble clapper_player_get_speed (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_video_sink (ClapperPlayer *player, GstElement *element);
 
+CLAPPER_API
 GstElement * clapper_player_get_video_sink (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_audio_sink (ClapperPlayer *player, GstElement *element);
 
+CLAPPER_API
 GstElement * clapper_player_get_audio_sink (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_video_filter (ClapperPlayer *player, GstElement *element);
 
+CLAPPER_API
 GstElement * clapper_player_get_video_filter (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_audio_filter (ClapperPlayer *player, GstElement *element);
 
+CLAPPER_API
 GstElement * clapper_player_get_audio_filter (ClapperPlayer *player);
 
+CLAPPER_API
 GstElement * clapper_player_get_current_video_decoder (ClapperPlayer *player);
 
+CLAPPER_API
 GstElement * clapper_player_get_current_audio_decoder (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_video_enabled (ClapperPlayer *player, gboolean enabled);
 
+CLAPPER_API
 gboolean clapper_player_get_video_enabled (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_audio_enabled (ClapperPlayer *player, gboolean enabled);
 
+CLAPPER_API
 gboolean clapper_player_get_audio_enabled (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_subtitles_enabled (ClapperPlayer *player, gboolean enabled);
 
+CLAPPER_API
 gboolean clapper_player_get_subtitles_enabled (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_download_dir (ClapperPlayer *player, const gchar *path);
 
+CLAPPER_API
 gchar * clapper_player_get_download_dir (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_download_enabled (ClapperPlayer *player, gboolean enabled);
 
+CLAPPER_API
 gboolean clapper_player_get_download_enabled (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_audio_offset (ClapperPlayer *player, gdouble offset);
 
+CLAPPER_API
 gdouble clapper_player_get_audio_offset (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_subtitle_offset (ClapperPlayer *player, gdouble offset);
 
+CLAPPER_API
 gdouble clapper_player_get_subtitle_offset (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_set_subtitle_font_desc (ClapperPlayer *player, const gchar *font_desc);
 
+CLAPPER_API
 gchar * clapper_player_get_subtitle_font_desc (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_play (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_pause (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_stop (ClapperPlayer *player);
 
+CLAPPER_API
 void clapper_player_seek (ClapperPlayer *player, gdouble position);
 
+CLAPPER_API
 void clapper_player_seek_custom (ClapperPlayer *player, gdouble position, ClapperPlayerSeekMethod method);
 
+CLAPPER_API
 void clapper_player_add_feature (ClapperPlayer *player, ClapperFeature *feature);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-queue.h
+++ b/src/lib/clapper/clapper-queue.h
@@ -27,6 +27,7 @@
 #include <glib-object.h>
 #include <gst/gst.h>
 
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-enums.h>
 #include <clapper/clapper-media-item.h>
 
@@ -35,6 +36,7 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_QUEUE (clapper_queue_get_type())
 #define CLAPPER_QUEUE_CAST(obj) ((ClapperQueue *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperQueue, clapper_queue, CLAPPER, QUEUE, GstObject)
 
 /**
@@ -44,50 +46,73 @@ G_DECLARE_FINAL_TYPE (ClapperQueue, clapper_queue, CLAPPER, QUEUE, GstObject)
  */
 #define CLAPPER_QUEUE_INVALID_POSITION ((guint) 0xffffffff)
 
+CLAPPER_API
 void clapper_queue_add_item (ClapperQueue *queue, ClapperMediaItem *item);
 
+CLAPPER_API
 void clapper_queue_insert_item (ClapperQueue *queue, ClapperMediaItem *item, gint index);
 
+CLAPPER_API
 void clapper_queue_reposition_item (ClapperQueue *queue, ClapperMediaItem *item, gint index);
 
+CLAPPER_API
 void clapper_queue_remove_item (ClapperQueue *queue, ClapperMediaItem *item);
 
+CLAPPER_API
 void clapper_queue_remove_index (ClapperQueue *queue, guint index);
 
+CLAPPER_API
 ClapperMediaItem * clapper_queue_steal_index (ClapperQueue *queue, guint index);
 
+CLAPPER_API
 void clapper_queue_clear (ClapperQueue *queue);
 
+CLAPPER_API
 gboolean clapper_queue_select_item (ClapperQueue *queue, ClapperMediaItem *item);
 
+CLAPPER_API
 gboolean clapper_queue_select_index (ClapperQueue *queue, guint index);
 
+CLAPPER_API
 gboolean clapper_queue_select_next_item (ClapperQueue *queue);
 
+CLAPPER_API
 gboolean clapper_queue_select_previous_item (ClapperQueue *queue);
 
+CLAPPER_API
 ClapperMediaItem * clapper_queue_get_item (ClapperQueue *queue, guint index);
 
+CLAPPER_API
 ClapperMediaItem * clapper_queue_get_current_item (ClapperQueue *queue);
 
+CLAPPER_API
 guint clapper_queue_get_current_index (ClapperQueue *queue);
 
+CLAPPER_API
 gboolean clapper_queue_item_is_current (ClapperQueue *queue, ClapperMediaItem *item);
 
+CLAPPER_API
 gboolean clapper_queue_find_item (ClapperQueue *queue, ClapperMediaItem *item, guint *index);
 
+CLAPPER_API
 guint clapper_queue_get_n_items (ClapperQueue *queue);
 
+CLAPPER_API
 void clapper_queue_set_progression_mode (ClapperQueue *queue, ClapperQueueProgressionMode mode);
 
+CLAPPER_API
 ClapperQueueProgressionMode clapper_queue_get_progression_mode (ClapperQueue *queue);
 
+CLAPPER_API
 void clapper_queue_set_gapless (ClapperQueue *queue, gboolean gapless);
 
+CLAPPER_API
 gboolean clapper_queue_get_gapless (ClapperQueue *queue);
 
+CLAPPER_API
 void clapper_queue_set_instant (ClapperQueue *queue, gboolean instant);
 
+CLAPPER_API
 gboolean clapper_queue_get_instant (ClapperQueue *queue);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-stream-list.h
+++ b/src/lib/clapper/clapper-stream-list.h
@@ -27,6 +27,7 @@
 #include <glib-object.h>
 #include <gst/gst.h>
 
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-stream.h>
 
 G_BEGIN_DECLS
@@ -34,6 +35,7 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_STREAM_LIST (clapper_stream_list_get_type())
 #define CLAPPER_STREAM_LIST_CAST(obj) ((ClapperStreamList *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperStreamList, clapper_stream_list, CLAPPER, STREAM_LIST, GstObject)
 
 /**
@@ -43,16 +45,22 @@ G_DECLARE_FINAL_TYPE (ClapperStreamList, clapper_stream_list, CLAPPER, STREAM_LI
  */
 #define CLAPPER_STREAM_LIST_INVALID_POSITION ((guint) 0xffffffff)
 
+CLAPPER_API
 gboolean clapper_stream_list_select_stream (ClapperStreamList *list, ClapperStream *stream);
 
+CLAPPER_API
 gboolean clapper_stream_list_select_index (ClapperStreamList *list, guint index);
 
+CLAPPER_API
 ClapperStream * clapper_stream_list_get_stream (ClapperStreamList *list, guint index);
 
+CLAPPER_API
 ClapperStream * clapper_stream_list_get_current_stream (ClapperStreamList *list);
 
+CLAPPER_API
 guint clapper_stream_list_get_current_index (ClapperStreamList *list);
 
+CLAPPER_API
 guint clapper_stream_list_get_n_streams (ClapperStreamList *list);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-stream.h
+++ b/src/lib/clapper/clapper-stream.h
@@ -27,6 +27,7 @@
 #include <glib-object.h>
 #include <gst/gst.h>
 
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-enums.h>
 
 G_BEGIN_DECLS
@@ -34,6 +35,7 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_STREAM (clapper_stream_get_type())
 #define CLAPPER_STREAM_CAST(obj) ((ClapperStream *)(obj))
 
+CLAPPER_API
 G_DECLARE_DERIVABLE_TYPE (ClapperStream, clapper_stream, CLAPPER, STREAM, GstObject)
 
 struct _ClapperStreamClass
@@ -58,8 +60,10 @@ struct _ClapperStreamClass
   gpointer padding[4];
 };
 
+CLAPPER_API
 ClapperStreamType clapper_stream_get_stream_type (ClapperStream *stream);
 
+CLAPPER_API
 gchar * clapper_stream_get_title (ClapperStream *stream);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-subtitle-stream.h
+++ b/src/lib/clapper/clapper-subtitle-stream.h
@@ -25,6 +25,8 @@
 
 #include <glib.h>
 #include <glib-object.h>
+
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-stream.h>
 
 G_BEGIN_DECLS
@@ -32,10 +34,13 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_SUBTITLE_STREAM (clapper_subtitle_stream_get_type())
 #define CLAPPER_SUBTITLE_STREAM_CAST(obj) ((ClapperSubtitleStream *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperSubtitleStream, clapper_subtitle_stream, CLAPPER, SUBTITLE_STREAM, ClapperStream)
 
+CLAPPER_API
 gchar * clapper_subtitle_stream_get_lang_code (ClapperSubtitleStream *stream);
 
+CLAPPER_API
 gchar * clapper_subtitle_stream_get_lang_name (ClapperSubtitleStream *stream);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-threaded-object.h
+++ b/src/lib/clapper/clapper-threaded-object.h
@@ -27,11 +27,14 @@
 #include <glib-object.h>
 #include <gst/gst.h>
 
+#include <clapper/clapper-visibility.h>
+
 G_BEGIN_DECLS
 
 #define CLAPPER_TYPE_THREADED_OBJECT (clapper_threaded_object_get_type())
 #define CLAPPER_THREADED_OBJECT_CAST(obj) ((ClapperThreadedObject *)(obj))
 
+CLAPPER_API
 G_DECLARE_DERIVABLE_TYPE (ClapperThreadedObject, clapper_threaded_object, CLAPPER, THREADED_OBJECT, GstObject)
 
 /**
@@ -68,6 +71,7 @@ struct _ClapperThreadedObjectClass
   gpointer padding[4];
 };
 
+CLAPPER_API
 GMainContext * clapper_threaded_object_get_context (ClapperThreadedObject *threaded_object);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-timeline.h
+++ b/src/lib/clapper/clapper-timeline.h
@@ -27,6 +27,7 @@
 #include <glib-object.h>
 #include <gst/gst.h>
 
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-marker.h>
 
 G_BEGIN_DECLS
@@ -34,14 +35,19 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_TIMELINE (clapper_timeline_get_type())
 #define CLAPPER_TIMELINE_CAST(obj) ((ClapperTimeline *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperTimeline, clapper_timeline, CLAPPER, TIMELINE, GstObject)
 
+CLAPPER_API
 gboolean clapper_timeline_insert_marker (ClapperTimeline *timeline, ClapperMarker *marker);
 
+CLAPPER_API
 void clapper_timeline_remove_marker (ClapperTimeline *timeline, ClapperMarker *marker);
 
+CLAPPER_API
 ClapperMarker * clapper_timeline_get_marker (ClapperTimeline *timeline, guint index);
 
+CLAPPER_API
 guint clapper_timeline_get_n_markers (ClapperTimeline *timeline);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-video-stream.h
+++ b/src/lib/clapper/clapper-video-stream.h
@@ -25,6 +25,8 @@
 
 #include <glib.h>
 #include <glib-object.h>
+
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-stream.h>
 
 G_BEGIN_DECLS
@@ -32,18 +34,25 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_VIDEO_STREAM (clapper_video_stream_get_type())
 #define CLAPPER_VIDEO_STREAM_CAST(obj) ((ClapperVideoStream *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperVideoStream, clapper_video_stream, CLAPPER, VIDEO_STREAM, ClapperStream)
 
+CLAPPER_API
 gchar * clapper_video_stream_get_codec (ClapperVideoStream *stream);
 
+CLAPPER_API
 gint clapper_video_stream_get_width (ClapperVideoStream *stream);
 
+CLAPPER_API
 gint clapper_video_stream_get_height (ClapperVideoStream *stream);
 
+CLAPPER_API
 gdouble clapper_video_stream_get_fps (ClapperVideoStream *stream);
 
+CLAPPER_API
 guint clapper_video_stream_get_bitrate (ClapperVideoStream *stream);
 
+CLAPPER_API
 gchar * clapper_video_stream_get_pixel_format (ClapperVideoStream *stream);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper.h
+++ b/src/lib/clapper/clapper.h
@@ -21,6 +21,8 @@
 
 #define __CLAPPER_INSIDE__
 
+#include <clapper/clapper-visibility.h>
+
 #include <clapper/clapper-enums.h>
 #include <clapper/clapper-version.h>
 
@@ -52,8 +54,10 @@
 
 G_BEGIN_DECLS
 
+CLAPPER_API
 void clapper_init (int *argc, char **argv[]);
 
+CLAPPER_API
 gboolean clapper_init_check (int *argc, char **argv[]);
 
 G_END_DECLS

--- a/src/lib/clapper/features/discoverer/clapper-discoverer.h
+++ b/src/lib/clapper/features/discoverer/clapper-discoverer.h
@@ -25,6 +25,8 @@
 
 #include <glib.h>
 #include <glib-object.h>
+
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-feature.h>
 
 G_BEGIN_DECLS
@@ -32,12 +34,16 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_DISCOVERER (clapper_discoverer_get_type())
 #define CLAPPER_DISCOVERER_CAST(obj) ((ClapperDiscoverer *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperDiscoverer, clapper_discoverer, CLAPPER, DISCOVERER, ClapperFeature)
 
+CLAPPER_API
 ClapperDiscoverer * clapper_discoverer_new (void);
 
+CLAPPER_API
 void clapper_discoverer_set_discovery_mode (ClapperDiscoverer *discoverer, ClapperDiscovererDiscoveryMode mode);
 
+CLAPPER_API
 ClapperDiscovererDiscoveryMode clapper_discoverer_get_discovery_mode (ClapperDiscoverer *discoverer);
 
 G_END_DECLS

--- a/src/lib/clapper/features/mpris/clapper-mpris.h
+++ b/src/lib/clapper/features/mpris/clapper-mpris.h
@@ -26,6 +26,8 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <gio/gio.h>
+
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-feature.h>
 
 G_BEGIN_DECLS
@@ -33,16 +35,22 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_MPRIS (clapper_mpris_get_type())
 #define CLAPPER_MPRIS_CAST(obj) ((ClapperMpris *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperMpris, clapper_mpris, CLAPPER, MPRIS, ClapperFeature)
 
+CLAPPER_API
 ClapperMpris * clapper_mpris_new (const gchar *own_name, const gchar *identity, const gchar *desktop_entry);
 
+CLAPPER_API
 void clapper_mpris_set_queue_controllable (ClapperMpris *mpris, gboolean controllable);
 
+CLAPPER_API
 gboolean clapper_mpris_get_queue_controllable (ClapperMpris *mpris);
 
+CLAPPER_API
 void clapper_mpris_set_fallback_art_url (ClapperMpris *mpris, const gchar *art_url);
 
+CLAPPER_API
 gchar * clapper_mpris_get_fallback_art_url (ClapperMpris *mpris);
 
 G_END_DECLS

--- a/src/lib/clapper/features/mpris/meson.build
+++ b/src/lib/clapper/features/mpris/meson.build
@@ -26,6 +26,14 @@ foreach dep : feature_deps
   endif
 endforeach
 
+gdbus_codegen = find_program('gdbus-codegen', required: false)
+if not gdbus_codegen.found()
+  if feature_option.enabled()
+    error('@0@ feature was enabled, but program gdbus-codegen was not found'.format(feature_name))
+  endif
+  subdir_done()
+endif
+
 clapper_mpris_gdbus = gnome.gdbus_codegen('clapper-mpris-gdbus',
   sources: 'clapper-mpris-gdbus.xml',
   interface_prefix: 'org.mpris.',

--- a/src/lib/clapper/features/server/clapper-server.h
+++ b/src/lib/clapper/features/server/clapper-server.h
@@ -25,6 +25,8 @@
 
 #include <glib.h>
 #include <glib-object.h>
+
+#include <clapper/clapper-visibility.h>
 #include <clapper/clapper-feature.h>
 
 G_BEGIN_DECLS
@@ -32,24 +34,34 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_SERVER (clapper_server_get_type())
 #define CLAPPER_SERVER_CAST(obj) ((ClapperServer *)(obj))
 
+CLAPPER_API
 G_DECLARE_FINAL_TYPE (ClapperServer, clapper_server, CLAPPER, SERVER, ClapperFeature)
 
+CLAPPER_API
 ClapperServer * clapper_server_new (void);
 
+CLAPPER_API
 void clapper_server_set_enabled (ClapperServer *server, gboolean enabled);
 
+CLAPPER_API
 gboolean clapper_server_get_enabled (ClapperServer *server);
 
+CLAPPER_API
 gboolean clapper_server_get_running (ClapperServer *server);
 
+CLAPPER_API
 void clapper_server_set_port (ClapperServer *server, guint port);
 
+CLAPPER_API
 guint clapper_server_get_port (ClapperServer *server);
 
+CLAPPER_API
 guint clapper_server_get_current_port (ClapperServer *server);
 
+CLAPPER_API
 void clapper_server_set_queue_controllable (ClapperServer *server, gboolean controllable);
 
+CLAPPER_API
 gboolean clapper_server_get_queue_controllable (ClapperServer *server);
 
 G_END_DECLS

--- a/src/lib/clapper/meson.build
+++ b/src/lib/clapper/meson.build
@@ -1,5 +1,6 @@
 clapper_dep = dependency('', required: false)
 clapper_option = get_option('clapper')
+clapper_headers_dir = join_paths(includedir, clapper_api_name, 'clapper')
 build_clapper = false
 
 clapper_pkg_reqs = [
@@ -37,6 +38,19 @@ foreach dep : clapper_deps
   endif
 endforeach
 
+visibility_conf = configuration_data()
+
+visibility_conf.set(
+  'CLAPPER_API',
+  'CLAPPER',
+)
+
+clapper_visibility_header = configure_file(
+  input: '../shared/clapper-api-visibility.h.in',
+  output: 'clapper-visibility.h',
+  configuration: visibility_conf,
+)
+
 version_conf = configuration_data()
 
 version_conf.set(
@@ -55,8 +69,6 @@ version_conf.set(
   'CLAPPER_MICRO_VERSION',
   version_array[2].to_int(),
 )
-
-clapper_headers_dir = join_paths(includedir, clapper_api_name, 'clapper')
 
 clapper_version_header = configure_file(
   input: 'clapper-version.h.in',
@@ -87,6 +99,7 @@ clapper_headers = [
   'clapper-utils.h',
   'clapper-video-stream.h',
   clapper_version_header,
+  clapper_visibility_header,
 ]
 clapper_sources = [
   'clapper.c',
@@ -115,11 +128,17 @@ clapper_c_args = [
   '-DGST_USE_UNSTABLE_API',
 ]
 
+if get_option('default_library') == 'static'
+  clapper_c_args += ['-DCLAPPER_STATIC_COMPILATION']
+endif
+
 subdir('features')
 
 clapper_enums = gnome.mkenums_simple(
   'clapper-enum-types',
   sources: clapper_headers,
+  decorator: 'CLAPPER_API',
+  header_prefix: '#include <clapper/clapper-visibility.h>',
   identifier_prefix: 'Clapper',
   symbol_prefix: 'clapper',
   install_header: true,
@@ -212,6 +231,7 @@ clapper_dep = declare_dependency(
   include_directories: clapper_conf_inc,
   dependencies: clapper_deps + clapper_features_deps,
   sources: [
+    clapper_visibility_header,
     clapper_version_header,
     clapper_features_availability_header,
     clapper_enums[1],

--- a/src/lib/gst/plugin/gstclappercontexthandler.h
+++ b/src/lib/gst/plugin/gstclappercontexthandler.h
@@ -22,6 +22,8 @@
 #include <gst/gst.h>
 #include <gst/base/gstbasesink.h>
 
+#include "gst/plugin/clapper-gst-visibility.h"
+
 G_BEGIN_DECLS
 
 #define GST_TYPE_CLAPPER_CONTEXT_HANDLER               (gst_clapper_context_handler_get_type())
@@ -53,10 +55,13 @@ struct _GstClapperContextHandlerClass
                                      GstQuery                 *query);
 };
 
+CLAPPER_GST_API
 GType                      gst_clapper_context_handler_get_type              (void);
 
+CLAPPER_GST_API
 gboolean                   gst_clapper_context_handler_handle_context_query  (GstClapperContextHandler *handler, GstBaseSink *bsink, GstQuery *query);
 
+CLAPPER_GST_API
 GstClapperContextHandler * gst_clapper_context_handler_obtain_with_type      (GPtrArray *context_handlers, GType type);
 
 G_END_DECLS

--- a/src/lib/gst/plugin/gstclapperimporter.h
+++ b/src/lib/gst/plugin/gstclapperimporter.h
@@ -23,6 +23,8 @@
 #include <gst/gst.h>
 #include <gst/video/video.h>
 
+#include "gst/plugin/clapper-gst-visibility.h"
+
 G_BEGIN_DECLS
 
 #define GST_TYPE_CLAPPER_IMPORTER               (gst_clapper_importer_get_type())
@@ -79,6 +81,7 @@ struct _GstClapperImporterClass
                                      GstVideoInfo       *v_info);
 };
 
+CLAPPER_GST_API
 GType           gst_clapper_importer_get_type                (void);
 
 GstBufferPool * gst_clapper_importer_create_pool             (GstClapperImporter *importer, GstStructure **config);

--- a/src/lib/gst/plugin/gstclapperimporterloader.c
+++ b/src/lib/gst/plugin/gstclapperimporterloader.c
@@ -115,11 +115,14 @@ _obtain_available_modules_once (G_GNUC_UNUSED gpointer data)
   GFile *dir;
   GFileEnumerator *dir_enum;
   GError *error = NULL;
+  const gchar *imp_path, *env_path = g_getenv ("CLAPPER_SINK_IMPORTER_PATH");
 
   GST_INFO ("Preparing modules");
 
   modules = g_ptr_array_new ();
-  dir = g_file_new_for_path (CLAPPER_SINK_IMPORTER_PATH);
+
+  imp_path = (env_path && env_path[0]) ? env_path : CLAPPER_SINK_IMPORTER_PATH;
+  dir = g_file_new_for_path (imp_path);
 
   if ((dir_enum = g_file_enumerate_children (dir,
       G_FILE_ATTRIBUTE_STANDARD_NAME,
@@ -139,7 +142,7 @@ _obtain_available_modules_once (G_GNUC_UNUSED gpointer data)
       if (!g_str_has_suffix (module_name, G_MODULE_SUFFIX))
         continue;
 
-      module_path = g_module_build_path (CLAPPER_SINK_IMPORTER_PATH, module_name);
+      module_path = g_module_build_path (imp_path, module_name);
       module = g_module_open (module_path, G_MODULE_BIND_LAZY);
       g_free (module_path);
 

--- a/src/lib/gst/plugin/gstgtkutils.h
+++ b/src/lib/gst/plugin/gstgtkutils.h
@@ -26,10 +26,14 @@
 #include <gtk/gtk.h>
 #include <gst/video/video.h>
 
+#include "gst/plugin/clapper-gst-visibility.h"
+
 G_BEGIN_DECLS
 
+CLAPPER_GST_API
 gpointer        gst_gtk_invoke_on_main                (GThreadFunc func, gpointer data);
 
+CLAPPER_GST_API
 GdkTexture *    gst_video_frame_into_gdk_texture      (GstVideoFrame *frame);
 
 void            gst_gtk_get_width_height_for_rotation (gint width, gint height,

--- a/src/lib/gst/plugin/handlers/gl/gstclapperglcontexthandler.h
+++ b/src/lib/gst/plugin/handlers/gl/gstclapperglcontexthandler.h
@@ -27,10 +27,13 @@
 #include <gtk/gtk.h>
 
 #include "gst/plugin/gstclappercontexthandler.h"
+#include "gst/plugin/clapper-gst-visibility.h"
 
 G_BEGIN_DECLS
 
 #define GST_TYPE_CLAPPER_GL_CONTEXT_HANDLER (gst_clapper_gl_context_handler_get_type())
+
+CLAPPER_GST_API
 G_DECLARE_FINAL_TYPE (GstClapperGLContextHandler, gst_clapper_gl_context_handler, GST, CLAPPER_GL_CONTEXT_HANDLER, GstClapperContextHandler)
 
 #define GST_CLAPPER_GL_CONTEXT_HANDLER_CAST(obj)        ((GstClapperGLContextHandler *)(obj))
@@ -55,10 +58,13 @@ struct _GstClapperGLContextHandler
   GstGLContext *gst_context;
 };
 
+CLAPPER_GST_API
 void         gst_clapper_gl_context_handler_add_handler            (GPtrArray *context_handlers);
 
+CLAPPER_GST_API
 GstCaps *    gst_clapper_gl_context_handler_make_gdk_gl_caps       (const gchar *features, gboolean only_2d);
 
+CLAPPER_GST_API
 GdkTexture * gst_clapper_gl_context_handler_make_gl_texture        (GstClapperGLContextHandler *handler, GstBuffer *buffer, GstVideoInfo *v_info);
 
 G_END_DECLS

--- a/src/lib/gst/plugin/meson.build
+++ b/src/lib/gst/plugin/meson.build
@@ -23,11 +23,15 @@ endforeach
 
 gst_clapper_plugin_args = [
   '-DHAVE_CONFIG_H',
+  '-DCLAPPER_GST_COMPILATION',
   '-DGST_USE_UNSTABLE_API',
 ]
 
 if get_option('default_library') == 'static'
-  gst_clapper_plugin_args += ['-DGST_STATIC_COMPILATION']
+  gst_clapper_plugin_args += [
+    '-DGST_STATIC_COMPILATION',
+    '-DCLAPPER_GST_STATIC_COMPILATION',
+  ]
 endif
 
 cdata = configuration_data()
@@ -46,6 +50,20 @@ configure_file(
   output: 'config.h',
   configuration: cdata,
 )
+
+visibility_conf = configuration_data()
+
+visibility_conf.set(
+  'CLAPPER_API',
+  'CLAPPER_GST',
+)
+
+clappergst_visibility_header = configure_file(
+  input: '../../shared/clapper-api-visibility.h.in',
+  output: 'clapper-gst-visibility.h',
+  configuration: visibility_conf,
+)
+
 gst_plugin_conf_inc = [
   include_directories('.'),
   include_directories('..'),

--- a/src/lib/shared/clapper-api-visibility.h.in
+++ b/src/lib/shared/clapper-api-visibility.h.in
@@ -1,0 +1,45 @@
+/* Clapper API Visibility
+ * Copyright (C) 2024 Rafał Dzięgiel <rafostar.github@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if !defined(__@CLAPPER_API@_INSIDE__) && !defined(@CLAPPER_API@_COMPILATION)
+#error "This header file can not be included directly."
+#endif
+
+#if (defined(_WIN32) || defined(__CYGWIN__)) && !defined(@CLAPPER_API@_STATIC_COMPILATION)
+#define _@CLAPPER_API@_EXPORT __declspec(dllexport) extern
+#define _@CLAPPER_API@_IMPORT __declspec(dllimport) extern
+#elif __GNUC__ >= 4
+#define _@CLAPPER_API@_EXPORT __attribute__((visibility("default"))) extern
+#define _@CLAPPER_API@_IMPORT extern
+#else
+#define _@CLAPPER_API@_EXPORT extern
+#define _@CLAPPER_API@_IMPORT extern
+#endif
+
+#if defined(@CLAPPER_API@_COMPILATION)
+#define _@CLAPPER_API@_VISIBILITY _@CLAPPER_API@_EXPORT
+#else
+#define _@CLAPPER_API@_VISIBILITY _@CLAPPER_API@_IMPORT
+#endif
+
+#define @CLAPPER_API@_API                _@CLAPPER_API@_VISIBILITY
+#define @CLAPPER_API@_DEPRECATED         G_DEPRECATED _@CLAPPER_API@_VISIBILITY
+#define @CLAPPER_API@_DEPRECATED_FOR(f)  G_DEPRECATED_FOR(f) _@CLAPPER_API@_VISIBILITY


### PR DESCRIPTION
Support building and running both Clapper libraries and application itself on MS Windows. Thankfully, newly rewritten code seems to be fine as-is and the only needed changes are supporting DLL visibility and some meson buildsystem tweaks.

Fixes #103