### PR TITLE
fix: adw 1.6 deprecations

### DIFF
--- a/src/bin/clapper-app/clapper-app-about-dialog.c
+++ b/src/bin/clapper-app/clapper-app-about-dialog.c
@@ -22,29 +22,24 @@
 #include <clapper/clapper.h>
 #include <adwaita.h>
 
-#include "clapper-app-about-window.h"
+#include "clapper-app-about-dialog.h"
 
 GtkWidget *
-clapper_app_about_window_new (GtkApplication *gtk_app)
+clapper_app_about_dialog_new (void)
 {
-  AdwAboutWindow *about;
-  GtkWindow *window;
+  AdwAboutDialog *about;
   GString *string;
   gchar *gst_ver, *debug_info;
 
-  about = ADW_ABOUT_WINDOW (adw_about_window_new_from_appdata (
+  about = ADW_ABOUT_DIALOG (adw_about_dialog_new_from_appdata (
       CLAPPER_APP_RESOURCE_PREFIX "/data/metainfo/" CLAPPER_APP_ID ".metainfo.xml",
       NULL));
-  window = gtk_application_get_active_window (gtk_app);
-
-  gtk_window_set_modal (GTK_WINDOW (about), TRUE);
-  gtk_window_set_transient_for (GTK_WINDOW (about), window);
 
   /* Also show development versions */
-  adw_about_window_set_version (about, CLAPPER_VERSION_S);
+  adw_about_dialog_set_version (about, CLAPPER_VERSION_S);
 
   /* TRANSLATORS: Put your name(s) here for credits or leave untranslated */
-  adw_about_window_set_translator_credits (about, _("translator-credits"));
+  adw_about_dialog_set_translator_credits (about, _("translator-credits"));
 
   string = g_string_new (NULL);
 
@@ -66,7 +61,7 @@ clapper_app_about_window_new (GtkApplication *gtk_app)
   g_free (gst_ver);
 
   debug_info = g_string_free_and_steal (string);
-  adw_about_window_set_debug_info (about, debug_info);
+  adw_about_dialog_set_debug_info (about, debug_info);
   g_free (debug_info);
 
   return GTK_WIDGET (about);

--- a/src/bin/clapper-app/clapper-app-about-dialog.h
+++ b/src/bin/clapper-app/clapper-app-about-dialog.h
@@ -24,6 +24,6 @@
 G_BEGIN_DECLS
 
 G_GNUC_INTERNAL
-GtkWidget * clapper_app_about_window_new (GtkApplication *gtk_app);
+GtkWidget * clapper_app_about_dialog_new (void);
 
 G_END_DECLS

--- a/src/bin/clapper-app/clapper-app-application.c
+++ b/src/bin/clapper-app/clapper-app-application.c
@@ -28,7 +28,7 @@
 #include "clapper-app-uri-dialog.h"
 #include "clapper-app-info-window.h"
 #include "clapper-app-preferences-window.h"
-#include "clapper-app-about-window.h"
+#include "clapper-app-about-dialog.h"
 #include "clapper-app-utils.h"
 
 #define PERCENTAGE_ROUND(a) (round ((gdouble) a / 0.01) * 0.01)
@@ -399,10 +399,12 @@ static void
 show_about (GSimpleAction *action, GVariant *param, gpointer user_data)
 {
   GtkApplication *gtk_app = GTK_APPLICATION (user_data);
-  GtkWidget *about_window;
+  GtkWindow *window;
+  GtkWidget *about_dialog;
 
-  about_window = clapper_app_about_window_new (gtk_app);
-  gtk_window_present (GTK_WINDOW (about_window));
+  window = gtk_application_get_active_window (gtk_app);
+  about_dialog = clapper_app_about_dialog_new ();
+  adw_dialog_present (ADW_DIALOG (about_dialog), GTK_WIDGET (window));
 }
 
 GApplication *

--- a/src/bin/clapper-app/meson.build
+++ b/src/bin/clapper-app/meson.build
@@ -67,7 +67,7 @@ configure_file(
 )
 
 clapperapp_sources = [
-  'clapper-app-about-window.c',
+  'clapper-app-about-dialog.c',
   'clapper-app-application.c',
   'clapper-app-file-dialog.c',
   'clapper-app-headerbar.c',

--- a/src/bin/clapper-app/ui/clapper-app-uri-dialog.ui
+++ b/src/bin/clapper-app/ui/clapper-app-uri-dialog.ui
@@ -1,21 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="clapper-app">
-  <object class="AdwMessageDialog" id="dialog">
-    <property name="modal">true</property>
-    <property name="width-request">420</property>
+  <object class="AdwAlertDialog" id="dialog">
     <property name="heading" translatable="yes">Add URI</property>
     <property name="body" translatable="yes">Insert an URI to be added to playback queue</property>
     <property name="close-response">cancel</property>
     <property name="default-response">add</property>
+    <property name="follows-content-size">false</property>
     <property name="extra-child">
-      <object class="GtkEntry">
-        <property name="halign">fill</property>
-        <property name="valign">center</property>
-        <property name="hexpand">true</property>
-        <property name="activates-default">true</property>
-        <property name="truncate-multiline">true</property>
-        <property name="input-purpose">url</property>
-        <property name="placeholder-text" translatable="yes">Enter or drop URI here</property>
+      <object class="GtkListBox">
+        <property name="selection-mode">none</property>
+        <style>
+          <class name="boxed-list"/>
+        </style>
+        <child>
+          <object class="AdwEntryRow" id="entry_row">
+            <property name="halign">fill</property>
+            <property name="valign">center</property>
+            <property name="hexpand">true</property>
+            <property name="activates-default">true</property>
+            <property name="input-purpose">url</property>
+            <property name="title" translatable="yes">Enter or drop URI here</property>
+          </object>
+        </child>
       </object>
     </property>
     <responses>

--- a/src/bin/clapper-app/ui/clapper-app-uri-dialog.ui
+++ b/src/bin/clapper-app/ui/clapper-app-uri-dialog.ui
@@ -6,6 +6,7 @@
     <property name="close-response">cancel</property>
     <property name="default-response">add</property>
     <property name="follows-content-size">false</property>
+    <property name="content-width">420</property>
     <property name="extra-child">
       <object class="GtkListBox">
         <property name="selection-mode">none</property>


### PR DESCRIPTION
Libadwaita 1.6 is around the corner so I migrated some dialogs to the non-deprecated versions:

AdwAboutWindow => AdwAboutDialog
AdwMessageDialog => AdwAlertDialog

I also changed the uri-dialog's GtkEntry to AdwEntryRow to better match the HIG

![image](https://github.com/user-attachments/assets/a6e7517b-56dd-49de-a524-8b3563cba0ca)

My C is a bit rusty, let me know if I should change something or if I should split this PR into smaller ones!

Additionally, there's another change that should be done but it's a bit too much for me to do, the main window should become AdwWindow / AdwApplicationWindow to take full advantage of the dialogs. Those windows can display the dialogs inside of them instead of creating new ones and making them modals, which has the added bonus of the dialogs becoming bottom-sheets on narrow window sizes to better fit mobile devices