### PR TITLE
Remove "Music" from Clapper's keywords to lower its priority as a music player

### DIFF
--- a/src/bin/clapper-app/data/applications/com.github.rafostar.Clapper.desktop.in
+++ b/src/bin/clapper-app/data/applications/com.github.rafostar.Clapper.desktop.in
@@ -12,7 +12,7 @@ StartupNotify=true
 Terminal=false
 Type=Application
 # Translators: Search terms to find this application. Do NOT translate the semicolons!
-Keywords=Video;Movie;Film;Clip;Series;Player;Playlist;DVD;TV;Disc;Album;Music;GNOME;Clapper;
+Keywords=Video;Movie;Film;Clip;Series;Player;Playlist;DVD;TV;Disc;Album;GNOME;Clapper;
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;
 Actions=new-window;

--- a/src/bin/clapper-app/data/applications/com.github.rafostar.Clapper.desktop.in
+++ b/src/bin/clapper-app/data/applications/com.github.rafostar.Clapper.desktop.in
@@ -12,7 +12,7 @@ StartupNotify=true
 Terminal=false
 Type=Application
 # Translators: Search terms to find this application. Do NOT translate the semicolons!
-Keywords=Video;Movie;Film;Clip;Series;Player;Playlist;DVD;TV;Disc;Album;GNOME;Clapper;
+Keywords=Video;Movie;Film;Clip;Series;Player;Playlist;DVD;TV;Disc;
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;
 Actions=new-window;


### PR DESCRIPTION
This PR removes several keywords from Clapper's `.desktop` file to improve search result relevance:

### Changes:
* Removed "Album" - redundant for video player
* Removed "GNOME" - not a GNOME-specific app
* Removed "Clapper" - already in app name/desktop file
* Removed "Music" - lower priority as music player

These changes adjust Clapper's visibility in application search results while maintaining all functionality.