### PR TITLE
Ability to show GStreamer pipeline

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -166,3 +166,8 @@ if build_clapper
     summary(name, clapper_available_features.contains(name) ? 'Yes' : 'No', section: 'Features')
   endforeach
 endif
+if build_clapperapp
+  foreach name : clapperapp_possible_functionalities
+    summary(name, clapperapp_available_functionalities.contains(name)  ? 'Yes' : 'No', section: 'Functionalities')
+  endforeach
+endif

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,12 @@ libadwaita_dep = dependency('libadwaita-1',
 peas_dep = dependency('libpeas-2',
   required: false,
 )
+cgraph_dep = dependency('libcgraph',
+  required: false,
+)
+gvc_dep = dependency('libgvc',
+  required: false,
+)
 
 cc = meson.get_compiler('c')
 libm = cc.find_library('m', required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -41,6 +41,11 @@ option('enhancers-loader',
   value: 'enabled',
   description: 'Ability to load libpeas based plugins that enhance capabilities'
 )
+option('pipeline-preview',
+  type: 'feature',
+  value: 'auto',
+  description: 'Ability to preview GStreamer pipeline in clapper-app'
+)
 
 # Features
 option('discoverer',

--- a/pkgs/flatpak/com.github.rafostar.Clapper-nightly.json
+++ b/pkgs/flatpak/com.github.rafostar.Clapper-nightly.json
@@ -66,6 +66,7 @@
         "testing/dav1d.json",
         "testing/gstreamer.json",
         "testing/gst-plugins-rs.json",
+        "testing/graphviz.json",
         {
             "name": "clapper",
             "buildsystem": "meson",

--- a/pkgs/flatpak/com.github.rafostar.Clapper.json
+++ b/pkgs/flatpak/com.github.rafostar.Clapper.json
@@ -51,6 +51,7 @@
         "flathub/lib/libmicrodns.json",
         "flathub/lib/libpeas.json",
         "flathub/gstreamer-1.0/gstreamer.json",
+        "testing/graphviz.json",
         {
             "name": "clapper",
             "buildsystem": "meson",

--- a/pkgs/flatpak/testing/graphviz.json
+++ b/pkgs/flatpak/testing/graphviz.json
@@ -1,0 +1,38 @@
+{
+    "name": "graphviz",
+    "buildsystem": "autotools",
+    "config-opts": [
+        "--without-x",
+        "--without-gtk",
+        "--without-gtkgl",
+        "--without-gtkglext",
+        "--without-gdk",
+        "--without-gdk-pixbuf",
+        "--without-qt",
+        "--disable-static",
+        "--disable-sharp",
+        "--disable-go",
+        "--disable-guile",
+        "--disable-java",
+        "--disable-javascript",
+        "--disable-lua",
+        "--disable-perl",
+        "--disable-php",
+        "--disable-python",
+        "--disable-r",
+        "--disable-ruby",
+        "--disable-tcl"
+    ],
+    "cleanup": [
+        "/bin",
+        "/share/man",
+        "/share/graphviz"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/graphviz-12.2.1.tar.gz",
+            "sha256": "242bc18942eebda6db4039f108f387ec97856fc91ba47f21e89341c34b554df8"
+        }
+    ]
+}

--- a/src/bin/clapper-app/clapper-app-application.h
+++ b/src/bin/clapper-app/clapper-app-application.h
@@ -19,6 +19,7 @@
 
 #include <glib.h>
 #include <glib-object.h>
+#include <gio/gio.h>
 #include <gtk/gtk.h>
 
 G_BEGIN_DECLS

--- a/src/bin/clapper-app/clapper-app-info-window.c
+++ b/src/bin/clapper-app/clapper-app-info-window.c
@@ -36,6 +36,8 @@ struct _ClapperAppInfoWindow
   GtkWidget *astreams_list;
   GtkWidget *sstreams_list;
 
+  GtkWidget *pipeline_button;
+
   ClapperPlayer *player;
 };
 
@@ -174,6 +176,10 @@ clapper_app_info_window_init (ClapperAppInfoWindow *self)
   gtk_widget_remove_css_class (self->vstreams_list, "view");
   gtk_widget_remove_css_class (self->astreams_list, "view");
   gtk_widget_remove_css_class (self->sstreams_list, "view");
+
+#ifdef HAVE_GRAPHVIZ
+  gtk_widget_set_visible (self->pipeline_button, TRUE);
+#endif
 }
 
 static void
@@ -256,6 +262,7 @@ clapper_app_info_window_class_init (ClapperAppInfoWindowClass *klass)
   gtk_widget_class_bind_template_child (widget_class, ClapperAppInfoWindow, vstreams_list);
   gtk_widget_class_bind_template_child (widget_class, ClapperAppInfoWindow, astreams_list);
   gtk_widget_class_bind_template_child (widget_class, ClapperAppInfoWindow, sstreams_list);
+  gtk_widget_class_bind_template_child (widget_class, ClapperAppInfoWindow, pipeline_button);
 
   gtk_widget_class_bind_template_callback (widget_class, media_duration_closure);
   gtk_widget_class_bind_template_callback (widget_class, playback_element_name_closure);

--- a/src/bin/clapper-app/clapper-app-utils.c
+++ b/src/bin/clapper-app/clapper-app-utils.c
@@ -542,8 +542,10 @@ clapper_app_utils_make_element (const gchar *string)
 static inline GFile *
 _get_tmp_dir (const gchar *subdir)
 {
+  /* XXX: System tmp directory does not work within containers such as Flatpak
+   * for our usage with file launcher, so make our own temp in app data dir */
   return g_file_new_build_filename (
-      g_get_tmp_dir (), "." CLAPPER_APP_ID, subdir, NULL);
+      g_get_user_data_dir (), CLAPPER_APP_ID, "tmp", subdir, NULL);
 }
 
 #ifdef HAVE_GRAPHVIZ

--- a/src/bin/clapper-app/clapper-app-utils.h
+++ b/src/bin/clapper-app/clapper-app-utils.h
@@ -85,7 +85,7 @@ G_GNUC_INTERNAL
 GstElement * clapper_app_utils_make_element (const gchar *string);
 
 G_GNUC_INTERNAL
-GFile * clapper_app_utils_create_pipeline_svg_file (ClapperPlayer *player, GError **error);
+void clapper_app_utils_create_pipeline_svg_file_async (ClapperPlayer *player, GCancellable *cancellable, GAsyncReadyCallback callback, gpointer user_data);
 
 G_GNUC_INTERNAL
 void clapper_app_utils_delete_tmp_dir (void);

--- a/src/bin/clapper-app/clapper-app-utils.h
+++ b/src/bin/clapper-app/clapper-app-utils.h
@@ -84,4 +84,7 @@ void clapper_app_utils_iterate_plugin_feature_ranks (GSettings *settings, Clappe
 G_GNUC_INTERNAL
 GstElement * clapper_app_utils_make_element (const gchar *string);
 
+G_GNUC_INTERNAL
+GFile * clapper_app_utils_create_pipeline_svg_file (ClapperPlayer *player, GError **error);
+
 G_END_DECLS

--- a/src/bin/clapper-app/clapper-app-utils.h
+++ b/src/bin/clapper-app/clapper-app-utils.h
@@ -87,4 +87,7 @@ GstElement * clapper_app_utils_make_element (const gchar *string);
 G_GNUC_INTERNAL
 GFile * clapper_app_utils_create_pipeline_svg_file (ClapperPlayer *player, GError **error);
 
+G_GNUC_INTERNAL
+void clapper_app_utils_delete_tmp_dir (void);
+
 G_END_DECLS

--- a/src/bin/clapper-app/main.c
+++ b/src/bin/clapper-app/main.c
@@ -74,5 +74,7 @@ main (gint argc, gchar **argv)
     clapper_app_utils_win_hi_res_clock_stop (resolution);
 #endif
 
+  clapper_app_utils_delete_tmp_dir ();
+
   return status;
 }

--- a/src/bin/clapper-app/meson.build
+++ b/src/bin/clapper-app/meson.build
@@ -94,12 +94,18 @@ clapperapp_c_args = [
   '-DGST_USE_UNSTABLE_API',
 ]
 
+clapperapp_possible_functionalities = [
+  'pipeline-preview',
+]
+clapperapp_available_functionalities = []
+
 pp_option = get_option('pipeline-preview')
 
 if not pp_option.disabled()
   if cgraph_dep.found() and gvc_dep.found()
     clapperapp_c_args += ['-DHAVE_GRAPHVIZ']
     clapperapp_deps += [cgraph_dep, gvc_dep]
+    clapperapp_available_functionalities += 'pipeline-preview'
   elif pp_option.enabled()
     error('pipeline-preview option was enabled, but required dependencies were not found')
   endif

--- a/src/bin/clapper-app/meson.build
+++ b/src/bin/clapper-app/meson.build
@@ -94,6 +94,17 @@ clapperapp_c_args = [
   '-DGST_USE_UNSTABLE_API',
 ]
 
+pp_option = get_option('pipeline-preview')
+
+if not pp_option.disabled()
+  if cgraph_dep.found() and gvc_dep.found()
+    clapperapp_c_args += ['-DHAVE_GRAPHVIZ']
+    clapperapp_deps += [cgraph_dep, gvc_dep]
+  elif pp_option.enabled()
+    error('pipeline-preview option was enabled, but required dependencies were not found')
+  endif
+endif
+
 is_windows = ['windows'].contains(host_machine.system())
 
 if is_windows

--- a/src/bin/clapper-app/ui/clapper-app-help-overlay.ui
+++ b/src/bin/clapper-app/ui/clapper-app-help-overlay.ui
@@ -28,6 +28,12 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes">Show pipeline</property>
+                <property name="accelerator">&lt;Ctrl&gt;&lt;Shift&gt;p</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes">Toggle fullscreen</property>
                 <property name="subtitle" translatable="yes">Double tap | Double click</property>
                 <property name="accelerator">F11 f</property>

--- a/src/bin/clapper-app/ui/clapper-app-info-window.ui
+++ b/src/bin/clapper-app/ui/clapper-app-info-window.ui
@@ -232,6 +232,17 @@
                                 </child>
                               </object>
                             </child>
+                            <child>
+                              <object class="GtkButton" id="pipeline_button">
+                                <property name="halign">center</property>
+                                <property name="label" translatable="yes">Show Pipeline</property>
+                                <property name="action-name">app.pipeline</property>
+                                <property name="visible">false</property>
+                                <style>
+                                  <class name="pill"/>
+                                </style>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>

--- a/src/lib/clapper/clapper-player.c
+++ b/src/lib/clapper/clapper-player.c
@@ -2187,6 +2187,28 @@ clapper_player_add_feature (ClapperPlayer *self, ClapperFeature *feature)
   clapper_features_manager_add_feature (self->features_manager, feature, GST_OBJECT (self));
 }
 
+/**
+ * clapper_player_make_pipeline_graph:
+ * @player: a #ClapperPlayer
+ * @details: a #GstDebugGraphDetails level
+ *
+ * Make current #GStreamer pipeline graph in `graphviz` dot format.
+ *
+ * Applications can use tools like `graphviz` to display returned
+ * data or just save it to a file as-is for the user to do it manually.
+ *
+ * Returns: (transfer full): current pipeline description in dot format.
+ *
+ * Since: 0.10
+ */
+gchar *
+clapper_player_make_pipeline_graph (ClapperPlayer *self, GstDebugGraphDetails details)
+{
+  g_return_val_if_fail (CLAPPER_IS_PLAYER (self), NULL);
+
+  return gst_debug_bin_to_dot_data (GST_BIN (self->playbin), details);
+}
+
 static void
 clapper_player_thread_start (ClapperThreadedObject *threaded_object)
 {

--- a/src/lib/clapper/clapper-player.h
+++ b/src/lib/clapper/clapper-player.h
@@ -204,4 +204,7 @@ void clapper_player_seek_custom (ClapperPlayer *player, gdouble position, Clappe
 CLAPPER_API
 void clapper_player_add_feature (ClapperPlayer *player, ClapperFeature *feature);
 
+CLAPPER_API
+gchar * clapper_player_make_pipeline_graph (ClapperPlayer *player, GstDebugGraphDetails details);
+
 G_END_DECLS


### PR DESCRIPTION
Allow users to preview GStreamer pipeline running underneath. It contains more data to help determine what exactly elements are used, what caps negotiated and where. Also helpful with debugging.

This implementation uses `GtkFileLauncher`, so users can open image with some app of their choice (usually image viewer). Implementing whole image viewer as part of video player would be an overkill.

This adds Graphviz as application dependency, but I made it in a way that app can be compiled without this functionality if this dependency gonna be inconvenient for some reason.