### PR TITLE
Use modern appstream, instead of appstream-util for validation

### DIFF
--- a/src/bin/clapper-app/data/meson.build
+++ b/src/bin/clapper-app/data/meson.build
@@ -1,10 +1,11 @@
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
+appstream_cli = find_program('appstreamcli', required: false)
+if appstream_cli.found()
   test('Validate appstream file',
-    appstream_util,
+    appstream_cli,
     args: [
-      'validate-relax',
-      '--nonet',
+      'validate',
+      '--no-net',
+      '--explain',
       join_paths(meson.current_source_dir(), 'metainfo', 'com.github.rafostar.Clapper.metainfo.xml'),
     ]
   )


### PR DESCRIPTION
Hi!

This patch switches from validating with `appstream-util` to validating with the more modern `appstreamcli`. This is also what Flatpak uses for validation, and we would like to eventually drop the former tool entirely.

Thank you for considering this patch! :-)