### PR TITLE
clapper: Ability to allow/disallow enhancers

### DIFF
--- a/src/bin/clapper-app/main.c
+++ b/src/bin/clapper-app/main.c
@@ -31,8 +31,10 @@
 gint
 main (gint argc, gchar **argv)
 {
-  const gchar *clapper_ldir;
   GApplication *application;
+  ClapperEnhancerProxyList *proxies;
+  const gchar *clapper_ldir;
+  guint i, n_proxies;
   gint status;
 
 #ifdef G_OS_WIN32
@@ -63,6 +65,15 @@ main (gint argc, gchar **argv)
   clapper_app_utils_win_enforce_hi_res_clock ();
   resolution = clapper_app_utils_win_hi_res_clock_start ();
 #endif
+
+  proxies = clapper_get_global_enhancer_proxies ();
+  n_proxies = clapper_enhancer_proxy_list_get_n_proxies (proxies);
+
+  /* Allow usage of all enhancers */
+  for (i = 0; i < n_proxies; ++i) {
+    ClapperEnhancerProxy *proxy = clapper_enhancer_proxy_list_peek_proxy (proxies, i);
+    clapper_enhancer_proxy_set_target_creation_allowed (proxy, TRUE);
+  }
 
   application = clapper_app_application_new ();
 

--- a/src/lib/clapper/clapper-enhancer-proxy.h
+++ b/src/lib/clapper/clapper-enhancer-proxy.h
@@ -76,4 +76,10 @@ void clapper_enhancer_proxy_set_locally (ClapperEnhancerProxy *proxy, const gcha
 CLAPPER_API
 void clapper_enhancer_proxy_set_locally_with_table (ClapperEnhancerProxy *proxy, GHashTable *table);
 
+CLAPPER_API
+void clapper_enhancer_proxy_set_target_creation_allowed (ClapperEnhancerProxy *proxy, gboolean allowed);
+
+CLAPPER_API
+gboolean clapper_enhancer_proxy_get_target_creation_allowed (ClapperEnhancerProxy *proxy);
+
 G_END_DECLS

--- a/src/lib/clapper/clapper-player.c
+++ b/src/lib/clapper/clapper-player.c
@@ -2339,8 +2339,6 @@ clapper_player_init (ClapperPlayer *self)
   if (clapper_enhancer_proxy_list_has_proxy_with_interface (self->enhancer_proxies, CLAPPER_TYPE_REACTABLE)) {
     self->reactables_manager = clapper_reactables_manager_new ();
     gst_object_set_parent (GST_OBJECT_CAST (self->reactables_manager), GST_OBJECT_CAST (self));
-
-    clapper_reactables_manager_trigger_prepare (self->reactables_manager);
   }
 
   self->position_query = gst_query_new_position (GST_FORMAT_TIME);

--- a/src/lib/clapper/clapper-reactables-manager-private.h
+++ b/src/lib/clapper/clapper-reactables-manager-private.h
@@ -37,9 +37,6 @@ G_GNUC_INTERNAL
 ClapperReactablesManager * clapper_reactables_manager_new (void);
 
 G_GNUC_INTERNAL
-void clapper_reactables_manager_trigger_prepare (ClapperReactablesManager *manager);
-
-G_GNUC_INTERNAL
 void clapper_reactables_manager_trigger_configure_take_config (ClapperReactablesManager *manager, ClapperEnhancerProxy *proxy, GstStructure *config);
 
 G_GNUC_INTERNAL

--- a/src/lib/clapper/gst/clapper-enhancer-director.c
+++ b/src/lib/clapper/gst/clapper-enhancer-director.c
@@ -93,7 +93,7 @@ clapper_enhancer_director_extract_in_thread (ClapperEnhancerDirectorData *data)
         clapper_enhancers_loader_create_enhancer (proxy, CLAPPER_TYPE_EXTRACTABLE));
 #endif
 
-    if (G_LIKELY (extractable != NULL)) {
+    if (extractable) {
       if (config)
         clapper_enhancer_proxy_apply_config_to_enhancer (proxy, config, (GObject *) extractable);
 


### PR DESCRIPTION
Some enhancer plugins (especially reactables) can potentially collide with some applications functionalities or simply cause issues if plugin code is buggy. For these reasons, lets add an API to disable them (by not allowing instances of them to be created completely).

Also, as a safety reason for other apps, lets make all non-ondemand enhancers (currently "reactables") to be disallowed (disabled) by default. Clapper app itself will be taking the risk through and enable all of them at init so testing/adding plugins to it is easier.