### PR TITLE
MPRIS compat changes

### DIFF
--- a/src/lib/clapper/clapper-enhancers-loader.c
+++ b/src/lib/clapper/clapper-enhancers-loader.c
@@ -34,8 +34,6 @@ static HMODULE _enhancers_dll_handle = NULL;
 #include "clapper-extractable.h"
 #include "clapper-reactable.h"
 
-#include <clapper-functionalities-availability.h>
-
 #define GST_CAT_DEFAULT clapper_enhancers_loader_debug
 GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 
@@ -133,36 +131,6 @@ clapper_enhancers_loader_initialize (ClapperEnhancerProxyList *proxies)
     PeasPluginInfo *info = (PeasPluginInfo *) g_list_model_get_item ((GListModel *) _engine, i);
     ClapperEnhancerProxy *proxy;
     gboolean filled;
-
-    /* FIXME: 1.0: Remove together with features code and manager.
-     * These would clash with each other, so avoid loading these
-     * as enhancers when also compiled as part of the library. */
-#if (CLAPPER_HAVE_MPRIS || CLAPPER_HAVE_DISCOVERER || CLAPPER_HAVE_SERVER)
-    guint f_index;
-    const gchar *module_name = peas_plugin_info_get_module_name (info);
-    const gchar *ported_features[] = {
-#if CLAPPER_HAVE_MPRIS
-      "clapper-mpris",
-#endif
-#if CLAPPER_HAVE_DISCOVERER
-      "clapper-discoverer",
-#endif
-#if CLAPPER_HAVE_SERVER
-      "clapper-server",
-#endif
-    };
-
-    for (f_index = 0; f_index < G_N_ELEMENTS (ported_features); ++f_index) {
-      if (strcmp (module_name, ported_features[f_index]) == 0) {
-        GST_INFO ("Skipped \"%s\" enhancer module, since its"
-          " loaded from deprecated feature object", module_name);
-        g_clear_object (&info);
-      }
-    }
-
-    if (!info) // cleared when exists as feature
-      continue;
-#endif
 
     /* Clapper supports only 1 proxy per plugin. Each plugin can
      * ship 1 class, but it can implement more than 1 interface. */

--- a/src/lib/clapper/features/mpris/clapper-mpris.c
+++ b/src/lib/clapper/features/mpris/clapper-mpris.c
@@ -23,6 +23,8 @@
  *
  * Not every OS supports `MPRIS`. Use [const@Clapper.HAVE_MPRIS] macro
  * to check if Clapper API was compiled with this feature.
+ *
+ * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
  */
 
 #include "clapper-mpris.h"
@@ -1346,6 +1348,8 @@ clapper_mpris_property_changed (ClapperFeature *feature, GParamSpec *pspec)
  * Creates a new #ClapperMpris instance.
  *
  * Returns: (transfer full): a new #ClapperMpris instance.
+ *
+ * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
  */
 ClapperMpris *
 clapper_mpris_new (const gchar *own_name, const gchar *identity,
@@ -1376,6 +1380,8 @@ clapper_mpris_new (const gchar *own_name, const gchar *identity,
  *
  * You probably want to keep this disabled if your application
  * is supposed to manage what is played now and not MPRIS client.
+ *
+ * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
  */
 void
 clapper_mpris_set_queue_controllable (ClapperMpris *self, gboolean controllable)
@@ -1397,6 +1403,8 @@ clapper_mpris_set_queue_controllable (ClapperMpris *self, gboolean controllable)
  * Get whether remote `MPRIS` clients can control [class@Clapper.Queue].
  *
  * Returns: %TRUE if control over #ClapperQueue is allowed, %FALSE otherwise.
+ *
+ * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
  */
 gboolean
 clapper_mpris_get_queue_controllable (ClapperMpris *self)
@@ -1412,6 +1420,8 @@ clapper_mpris_get_queue_controllable (ClapperMpris *self)
  * @art_url: (nullable): an art URL
  *
  * Set fallback artwork to show when media does not provide one.
+ *
+ * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
  */
 void
 clapper_mpris_set_fallback_art_url (ClapperMpris *self, const gchar *art_url)
@@ -1435,6 +1445,8 @@ clapper_mpris_set_fallback_art_url (ClapperMpris *self, const gchar *art_url)
  * Get fallback art URL earlier set by user.
  *
  * Returns: (transfer full) (nullable): fallback art URL.
+ *
+ * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
  */
 gchar *
 clapper_mpris_get_fallback_art_url (ClapperMpris *self)
@@ -1611,6 +1623,8 @@ clapper_mpris_class_init (ClapperMprisClass *klass)
    * Each #ClapperMpris instance running on the same system must have an unique name.
    *
    * Example: "org.mpris.MediaPlayer2.MyPlayer.instance123"
+   *
+   * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
    */
   param_specs[PROP_OWN_NAME] = g_param_spec_string ("own-name",
       NULL, NULL, NULL,
@@ -1622,6 +1636,8 @@ clapper_mpris_class_init (ClapperMprisClass *klass)
    * A friendly name to identify the media player.
    *
    * Example: "My Player"
+   *
+   * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
    */
   param_specs[PROP_IDENTITY] = g_param_spec_string ("identity",
       NULL, NULL, NULL,
@@ -1631,6 +1647,8 @@ clapper_mpris_class_init (ClapperMprisClass *klass)
    * ClapperMpris:desktop-entry:
    *
    * The basename of an installed .desktop file with the ".desktop" extension stripped.
+   *
+   * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
    */
   param_specs[PROP_DESKTOP_ENTRY] = g_param_spec_string ("desktop-entry",
       NULL, NULL, NULL,
@@ -1640,6 +1658,8 @@ clapper_mpris_class_init (ClapperMprisClass *klass)
    * ClapperMpris:queue-controllable:
    *
    * Whether remote MPRIS clients can control #ClapperQueue.
+   *
+   * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
    */
   param_specs[PROP_QUEUE_CONTROLLABLE] = g_param_spec_boolean ("queue-controllable",
       NULL, NULL, DEFAULT_QUEUE_CONTROLLABLE,
@@ -1649,6 +1669,8 @@ clapper_mpris_class_init (ClapperMprisClass *klass)
    * ClapperMpris:fallback-art-url:
    *
    * Fallback artwork to show when media does not provide one.
+   *
+   * Deprecated: 0.10: Use MPRIS from `clapper-enhancers` repo instead.
    */
   param_specs[PROP_FALLBACK_ART_URL] = g_param_spec_string ("fallback-art-url",
       NULL, NULL, NULL,

--- a/src/lib/clapper/features/mpris/clapper-mpris.h
+++ b/src/lib/clapper/features/mpris/clapper-mpris.h
@@ -34,22 +34,22 @@ G_BEGIN_DECLS
 #define CLAPPER_TYPE_MPRIS (clapper_mpris_get_type())
 #define CLAPPER_MPRIS_CAST(obj) ((ClapperMpris *)(obj))
 
-CLAPPER_API
+CLAPPER_DEPRECATED
 G_DECLARE_FINAL_TYPE (ClapperMpris, clapper_mpris, CLAPPER, MPRIS, ClapperFeature)
 
-CLAPPER_API
+CLAPPER_DEPRECATED
 ClapperMpris * clapper_mpris_new (const gchar *own_name, const gchar *identity, const gchar *desktop_entry);
 
-CLAPPER_API
+CLAPPER_DEPRECATED
 void clapper_mpris_set_queue_controllable (ClapperMpris *mpris, gboolean controllable);
 
-CLAPPER_API
+CLAPPER_DEPRECATED
 gboolean clapper_mpris_get_queue_controllable (ClapperMpris *mpris);
 
-CLAPPER_API
+CLAPPER_DEPRECATED
 void clapper_mpris_set_fallback_art_url (ClapperMpris *mpris, const gchar *art_url);
 
-CLAPPER_API
+CLAPPER_DEPRECATED
 gchar * clapper_mpris_get_fallback_art_url (ClapperMpris *mpris);
 
 G_END_DECLS


### PR DESCRIPTION
Handle both old MPRIS feature and it as newly ported to MPRIS enhancer within single process.
The aim is to not require building Clapper with MPRIS disabled and still be able to use new implementation.
MPRIS is enhancers repo already has required changes in place.