### PR TITLE
lib: Add runtime version information

### DIFF
--- a/src/lib/clapper-gtk/clapper-gtk-version.c
+++ b/src/lib/clapper-gtk/clapper-gtk-version.c
@@ -1,0 +1,95 @@
+/* Clapper GTK Integration Library
+ * Copyright (C) 2025 Rafał Dzięgiel <rafostar.github@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+#include "clapper-gtk-version.h"
+
+/**
+ * clapper_gtk_get_major_version:
+ *
+ * ClapperGtk runtime major version component
+ *
+ * This returns the ClapperGtk library version your code is
+ * running against unlike [const@ClapperGtk.MAJOR_VERSION]
+ * which represents compile time version.
+ *
+ * Returns: the major version number of the ClapperGtk library
+ *
+ * Since: 0.10
+ */
+guint
+clapper_gtk_get_major_version (void)
+{
+  return CLAPPER_GTK_MAJOR_VERSION;
+}
+
+/**
+ * clapper_gtk_get_minor_version:
+ *
+ * ClapperGtk runtime minor version component
+ *
+ * This returns the ClapperGtk library version your code is
+ * running against unlike [const@ClapperGtk.MINOR_VERSION]
+ * which represents compile time version.
+ *
+ * Returns: the minor version number of the ClapperGtk library
+ *
+ * Since: 0.10
+ */
+guint
+clapper_gtk_get_minor_version (void)
+{
+  return CLAPPER_GTK_MINOR_VERSION;
+}
+
+/**
+ * clapper_gtk_get_micro_version:
+ *
+ * ClapperGtk runtime micro version component
+ *
+ * This returns the ClapperGtk library version your code is
+ * running against unlike [const@ClapperGtk.MICRO_VERSION]
+ * which represents compile time version.
+ *
+ * Returns: the micro version number of the ClapperGtk library
+ *
+ * Since: 0.10
+ */
+guint
+clapper_gtk_get_micro_version (void)
+{
+  return CLAPPER_GTK_MICRO_VERSION;
+}
+
+/**
+ * clapper_gtk_get_version_s:
+ *
+ * ClapperGtk runtime version as string
+ *
+ * This returns the ClapperGtk library version your code is
+ * running against unlike [const@ClapperGtk.VERSION_S]
+ * which represents compile time version.
+ *
+ * Returns: the version of the ClapperGtk library as string
+ *
+ * Since: 0.10
+ */
+const gchar *
+clapper_gtk_get_version_s (void)
+{
+  return CLAPPER_GTK_VERSION_S;
+}

--- a/src/lib/clapper-gtk/clapper-gtk-version.h.in
+++ b/src/lib/clapper-gtk/clapper-gtk-version.h.in
@@ -22,6 +22,8 @@
 #error "Only <clapper-gtk/clapper-gtk.h> can be included directly."
 #endif
 
+#include <glib.h>
+
 /**
  * CLAPPER_GTK_MAJOR_VERSION:
  *
@@ -73,3 +75,15 @@
     (CLAPPER_GTK_MAJOR_VERSION == (major) && CLAPPER_GTK_MINOR_VERSION > (minor)) || \
     (CLAPPER_GTK_MAJOR_VERSION == (major) && CLAPPER_GTK_MINOR_VERSION == (minor) && \
     CLAPPER_GTK_MICRO_VERSION >= (micro)))
+
+G_BEGIN_DECLS
+
+guint clapper_gtk_get_major_version (void);
+
+guint clapper_gtk_get_minor_version (void);
+
+guint clapper_gtk_get_micro_version (void);
+
+const gchar * clapper_gtk_get_version_s (void);
+
+G_END_DECLS

--- a/src/lib/clapper-gtk/meson.build
+++ b/src/lib/clapper-gtk/meson.build
@@ -131,6 +131,7 @@ clappergtk_sources = [
   'clapper-gtk-toggle-fullscreen-button.c',
   'clapper-gtk-toggle-play-button.c',
   'clapper-gtk-utils.c',
+  'clapper-gtk-version.c',
   'clapper-gtk-video.c',
   'clapper-gtk-video-placeholder.c',
   clappergtk_resources,

--- a/src/lib/clapper/clapper-version.c
+++ b/src/lib/clapper/clapper-version.c
@@ -1,0 +1,95 @@
+/* Clapper Playback Library
+ * Copyright (C) 2025 Rafał Dzięgiel <rafostar.github@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+#include "clapper-version.h"
+
+/**
+ * clapper_get_major_version:
+ *
+ * Clapper runtime major version component
+ *
+ * This returns the Clapper library version your code is
+ * running against unlike [const@Clapper.MAJOR_VERSION]
+ * which represents compile time version.
+ *
+ * Returns: the major version number of the Clapper library
+ *
+ * Since: 0.10
+ */
+guint
+clapper_get_major_version (void)
+{
+  return CLAPPER_MAJOR_VERSION;
+}
+
+/**
+ * clapper_get_minor_version:
+ *
+ * Clapper runtime minor version component
+ *
+ * This returns the Clapper library version your code is
+ * running against unlike [const@Clapper.MINOR_VERSION]
+ * which represents compile time version.
+ *
+ * Returns: the minor version number of the Clapper library
+ *
+ * Since: 0.10
+ */
+guint
+clapper_get_minor_version (void)
+{
+  return CLAPPER_MINOR_VERSION;
+}
+
+/**
+ * clapper_get_micro_version:
+ *
+ * Clapper runtime micro version component
+ *
+ * This returns the Clapper library version your code is
+ * running against unlike [const@Clapper.MICRO_VERSION]
+ * which represents compile time version.
+ *
+ * Returns: the micro version number of the Clapper library
+ *
+ * Since: 0.10
+ */
+guint
+clapper_get_micro_version (void)
+{
+  return CLAPPER_MICRO_VERSION;
+}
+
+/**
+ * clapper_get_version_s:
+ *
+ * Clapper runtime version as string
+ *
+ * This returns the Clapper library version your code is
+ * running against unlike [const@Clapper.VERSION_S]
+ * which represents compile time version.
+ *
+ * Returns: the version of the Clapper library as string
+ *
+ * Since: 0.10
+ */
+const gchar *
+clapper_get_version_s (void)
+{
+  return CLAPPER_VERSION_S;
+}

--- a/src/lib/clapper/clapper-version.h.in
+++ b/src/lib/clapper/clapper-version.h.in
@@ -22,6 +22,8 @@
 #error "Only <clapper/clapper.h> can be included directly."
 #endif
 
+#include <glib.h>
+
 /**
  * CLAPPER_MAJOR_VERSION:
  *
@@ -73,3 +75,15 @@
     (CLAPPER_MAJOR_VERSION == (major) && CLAPPER_MINOR_VERSION > (minor)) || \
     (CLAPPER_MAJOR_VERSION == (major) && CLAPPER_MINOR_VERSION == (minor) && \
     CLAPPER_MICRO_VERSION >= (micro)))
+
+G_BEGIN_DECLS
+
+guint clapper_get_major_version (void);
+
+guint clapper_get_minor_version (void);
+
+guint clapper_get_micro_version (void);
+
+const gchar * clapper_get_version_s (void);
+
+G_END_DECLS

--- a/src/lib/clapper/meson.build
+++ b/src/lib/clapper/meson.build
@@ -158,6 +158,7 @@ clapper_sources = [
   'clapper-threaded-object.c',
   'clapper-timeline.c',
   'clapper-utils.c',
+  'clapper-version.c',
   'clapper-video-stream.c',
   'gst/clapper-plugin.c',
   'gst/clapper-extractable-src.c',


### PR DESCRIPTION
Allows apps to check the library version app is run against, contrary to compiled against