### PR TITLE
flatpak: Reverse enhancers extension preference order

### DIFF
--- a/pkgs/flatpak/com.github.rafostar.Clapper-nightly.json
+++ b/pkgs/flatpak/com.github.rafostar.Clapper-nightly.json
@@ -16,7 +16,7 @@
             "autodelete": false
         },
         "com.github.rafostar.Clapper.Enhancers": {
-            "versions": "master;test;stable",
+            "versions": "stable;test;master",
             "directory": "extensions/clapper/enhancers",
             "add-ld-path": "lib",
             "no-autodownload": false,

--- a/pkgs/flatpak/com.github.rafostar.Clapper.json
+++ b/pkgs/flatpak/com.github.rafostar.Clapper.json
@@ -12,7 +12,7 @@
             "autodelete": false
         },
         "com.github.rafostar.Clapper.Enhancers": {
-            "versions": "master;test;stable",
+            "versions": "stable;test;master",
             "directory": "extensions/clapper/enhancers",
             "add-ld-path": "lib",
             "no-autodownload": false,


### PR DESCRIPTION
It seems that Flatpak selects first available branch from the end, not start