### PR TITLE
clapper: Add simple enhancer proxy jobs management

### DIFF
--- a/src/lib/clapper/clapper-enhancer-proxy-private.h
+++ b/src/lib/clapper/clapper-enhancer-proxy-private.h
@@ -53,4 +53,10 @@ GstStructure * clapper_enhancer_proxy_make_current_config (ClapperEnhancerProxy 
 G_GNUC_INTERNAL
 void clapper_enhancer_proxy_apply_config_to_enhancer (ClapperEnhancerProxy *proxy, const GstStructure *config, GObject *enhancer);
 
+G_GNUC_INTERNAL
+void clapper_enhancer_proxy_await_job_start (ClapperEnhancerProxy *proxy, guint job_id);
+
+G_GNUC_INTERNAL
+void clapper_enhancer_proxy_remove_job (ClapperEnhancerProxy *proxy, guint job_id);
+
 G_END_DECLS


### PR DESCRIPTION
Allows to mark a job with a given ID as started, then when another thread/instance wants to process the same ID we can detect it and await previous job finish. This is especially useful for not extracting the same URI concurrently while still allowing to process multiple different URIs at once without blocking.