### PR TITLE
Support non-flush seek

### DIFF
--- a/src/bin/clapper-app/clapper-app-preferences-window.c
+++ b/src/bin/clapper-app/clapper-app-preferences-window.c
@@ -816,6 +816,8 @@ seek_method_name_closure (AdwEnumListItem *list_item, gpointer *user_data G_GNUC
       return g_strdup (_("Normal"));
     case CLAPPER_PLAYER_SEEK_METHOD_FAST:
       return g_strdup (_("Fast"));
+    case CLAPPER_PLAYER_SEEK_METHOD_NONFLUSH:
+      return g_strdup (_("Non-flush"));
     default:
       return NULL;
   }

--- a/src/lib/clapper/clapper-enums.h
+++ b/src/lib/clapper/clapper-enums.h
@@ -46,12 +46,14 @@ typedef enum
  * @CLAPPER_PLAYER_SEEK_METHOD_ACCURATE: Seek to exact position (slow).
  * @CLAPPER_PLAYER_SEEK_METHOD_NORMAL: Seek to approximated position.
  * @CLAPPER_PLAYER_SEEK_METHOD_FAST: Seek to position of nearest keyframe (fast).
+ * @CLAPPER_PLAYER_SEEK_METHOD_NONFLUSH: Seek without flushing buffers (for devices do not support flush).
  */
 typedef enum
 {
   CLAPPER_PLAYER_SEEK_METHOD_ACCURATE = 0,
   CLAPPER_PLAYER_SEEK_METHOD_NORMAL,
   CLAPPER_PLAYER_SEEK_METHOD_FAST,
+  CLAPPER_PLAYER_SEEK_METHOD_NONFLUSH,
 } ClapperPlayerSeekMethod;
 
 /**

--- a/src/lib/clapper/clapper-playbin-bus.c
+++ b/src/lib/clapper/clapper-playbin-bus.c
@@ -436,6 +436,12 @@ _handle_seek_msg (GstMessage *msg, const GstStructure *structure, ClapperPlayer 
     return;
   }
 
+  if (seek_method == CLAPPER_PLAYER_SEEK_METHOD_NONFLUSH && player->current_state != GST_STATE_PLAYING) {
+    /* Cannot do non-flush seek when not playing
+     * Resume playing first */
+    gst_element_set_state(player->playbin, GST_STATE_PLAYING);
+  }
+
   switch (seek_method) {
     case CLAPPER_PLAYER_SEEK_METHOD_FAST:
       flags |= (GST_SEEK_FLAG_KEY_UNIT | GST_SEEK_FLAG_SNAP_NEAREST);
@@ -444,6 +450,9 @@ _handle_seek_msg (GstMessage *msg, const GstStructure *structure, ClapperPlayer 
       break;
     case CLAPPER_PLAYER_SEEK_METHOD_ACCURATE:
       flags |= GST_SEEK_FLAG_ACCURATE;
+      break;
+    case CLAPPER_PLAYER_SEEK_METHOD_NONFLUSH:
+      flags = GST_SEEK_FLAG_NONE;
       break;
     default:
       g_assert_not_reached ();
@@ -465,13 +474,24 @@ _handle_seek_msg (GstMessage *msg, const GstStructure *structure, ClapperPlayer 
 
   GST_DEBUG ("Seeking with rate %.2lf to: %" GST_TIME_FORMAT,
       rate, GST_TIME_ARGS (position));
-
-  clapper_player_remove_tick_source (player);
-
-  if (!(player->seeking = gst_element_send_event (player->playbin, seek_event))) {
-    /* FIXME: Should we maybe call _handle_error_msg with
-     * some error here? Or will playbin post such message for us? */
-    GST_ERROR ("Could not seek");
+  if (flags == GST_SEEK_FLAG_NONE) {
+    if (!gst_element_send_event (player->playbin, seek_event)) {
+      GST_ERROR ("Could not seek");
+    }
+    /* Immediately post seek-done signal
+     * NOTE: Non-flush seek does not change player state.
+     * And there is no callback available for non-flush seek,
+     * therefore the best we can do is to immediately finish. */
+    clapper_app_bus_post_simple_signal (player->app_bus,
+        GST_OBJECT_CAST (player), g_signal_lookup ("seek-done", CLAPPER_TYPE_PLAYER));
+  } else {
+    clapper_player_remove_tick_source (player);
+  
+    if (!(player->seeking = gst_element_send_event (player->playbin, seek_event))) {
+      /* FIXME: Should we maybe call _handle_error_msg with
+       * some error here? Or will playbin post such message for us? */
+      GST_ERROR ("Could not seek");
+    }
   }
 }
 


### PR DESCRIPTION
On my chromebook device, the hardware video decoder driver is qcom venus, which does not support `flush` seek (the program will hang when seeking). I add an option to use non-flush seek mode.