### PR TITLE
clapper: Fix enum/flags enhancer param spec handling

### DIFF
--- a/src/lib/clapper/clapper-enhancer-proxy-private.h
+++ b/src/lib/clapper/clapper-enhancer-proxy-private.h
@@ -45,6 +45,9 @@ G_GNUC_INTERNAL
 GObject * clapper_enhancer_proxy_get_peas_info (ClapperEnhancerProxy *proxy);
 
 G_GNUC_INTERNAL
+GParamSpec * clapper_enhancer_proxy_find_target_pspec_by_name (ClapperEnhancerProxy *proxy, const gchar *name);
+
+G_GNUC_INTERNAL
 gboolean clapper_enhancer_proxy_has_locally_set (ClapperEnhancerProxy *proxy, const gchar *property_name);
 
 G_GNUC_INTERNAL

--- a/src/lib/clapper/clapper-enhancer-proxy.c
+++ b/src/lib/clapper/clapper-enhancer-proxy.c
@@ -520,6 +520,26 @@ clapper_enhancer_proxy_get_peas_info (ClapperEnhancerProxy *self)
   return self->peas_info;
 }
 
+GParamSpec *
+clapper_enhancer_proxy_find_target_pspec_by_name (ClapperEnhancerProxy *self, const gchar *name)
+{
+  guint i;
+
+  name = g_intern_string (name);
+  for (i = 0; i < self->n_pspecs; ++i) {
+    GParamSpec *pspec = self->pspecs[i];
+
+    /* GParamSpec names are always interned */
+    if (pspec->name == name)
+      return pspec;
+  }
+
+  g_warning ("No property \"%s\" in target of \"%s\" (%s)",
+      name, self->friendly_name, self->module_name);
+
+  return NULL;
+}
+
 gboolean
 clapper_enhancer_proxy_has_locally_set (ClapperEnhancerProxy *self, const gchar *property_name)
 {
@@ -575,7 +595,7 @@ clapper_enhancer_proxy_make_current_config (ClapperEnhancerProxy *self)
       if (!g_variant_equal (val, def)) {
         GValue value = G_VALUE_INIT;
 
-        if (G_LIKELY (clapper_utils_set_value_from_variant (&value, val))) {
+        if (G_LIKELY (clapper_utils_set_value_for_enhancer (&value, pspec, settings, val))) {
           if (!merged_config)
             merged_config = gst_structure_new_empty (CONFIG_STRUCTURE_NAME);
 
@@ -986,26 +1006,6 @@ clapper_enhancer_proxy_get_settings (ClapperEnhancerProxy *self)
   return settings;
 }
 
-static GParamSpec *
-_find_target_pspec_by_name (ClapperEnhancerProxy *self, const gchar *name)
-{
-  guint i;
-
-  name = g_intern_string (name);
-  for (i = 0; i < self->n_pspecs; ++i) {
-    GParamSpec *pspec = self->pspecs[i];
-
-    /* GParamSpec names are always interned */
-    if (pspec->name == name)
-      return pspec;
-  }
-
-  g_warning ("No property \"%s\" in target of \"%s\" (%s)",
-      name, self->friendly_name, self->module_name);
-
-  return NULL;
-}
-
 static gboolean
 _structure_take_value_by_pspec (ClapperEnhancerProxy *self,
     GstStructure *structure, GParamSpec *pspec, GValue *value)
@@ -1080,7 +1080,7 @@ clapper_enhancer_proxy_set_locally (ClapperEnhancerProxy *self, const gchar *fir
   name = first_property_name;
 
   while (name) {
-    GParamSpec *pspec = _find_target_pspec_by_name (self, name);
+    GParamSpec *pspec = clapper_enhancer_proxy_find_target_pspec_by_name (self, name);
 
     if (G_LIKELY (pspec != NULL)) {
       GValue value = G_VALUE_INIT;
@@ -1148,7 +1148,7 @@ clapper_enhancer_proxy_set_locally_with_table (ClapperEnhancerProxy *self, GHash
   g_hash_table_iter_init (&iter, table);
   while (g_hash_table_iter_next (&iter, &key_ptr, &val_ptr)) {
     const gchar *name = (const gchar *) key_ptr;
-    GParamSpec *pspec = _find_target_pspec_by_name (self, name);
+    GParamSpec *pspec = clapper_enhancer_proxy_find_target_pspec_by_name (self, name);
 
     if (G_LIKELY (pspec != NULL)) {
       GValue value_copy = G_VALUE_INIT;

--- a/src/lib/clapper/clapper-reactables-manager.c
+++ b/src/lib/clapper/clapper-reactables-manager.c
@@ -127,15 +127,21 @@ _settings_changed_cb (GSettings *settings, const gchar *key, ClapperReactableMan
   /* Local settings are applied through bus events, so all that is
    * needed here is a check to not overwrite locally set setting */
   if (!clapper_enhancer_proxy_has_locally_set (data->proxy, key)) {
-    GVariant *variant = g_settings_get_value (settings, key);
-    GValue value = G_VALUE_INIT;
+    GParamSpec *pspec = clapper_enhancer_proxy_find_target_pspec_by_name (data->proxy, key);
 
-    if (G_LIKELY (clapper_utils_set_value_from_variant (&value, variant))) {
-      g_object_set_property (G_OBJECT (data->reactable), key, &value);
-      g_value_unset (&value);
+    if (G_LIKELY (pspec != NULL)) {
+      GVariant *variant = g_settings_get_value (settings, key);
+      GValue value = G_VALUE_INIT;
+
+      if (G_LIKELY (clapper_utils_set_value_for_enhancer (&value, pspec, settings, variant))) {
+        g_object_set_property (G_OBJECT (data->reactable), key, &value);
+        g_value_unset (&value);
+      }
+
+      g_variant_unref (variant);
+    } else {
+      GST_ERROR_OBJECT (data->reactable, "Changed setting of non-existing property: %s", key);
     }
-
-    g_variant_unref (variant);
   }
 }
 

--- a/src/lib/clapper/clapper-utils-private.h
+++ b/src/lib/clapper/clapper-utils-private.h
@@ -59,6 +59,6 @@ G_GNUC_INTERNAL
 gchar * clapper_utils_title_from_uri (const gchar *uri);
 
 G_GNUC_INTERNAL
-gboolean clapper_utils_set_value_from_variant (GValue *value, GVariant *variant);
+gboolean clapper_utils_set_value_for_enhancer (GValue *value, GParamSpec *pspec, GSettings *settings, GVariant *variant);
 
 G_END_DECLS

--- a/src/lib/clapper/clapper-utils.c
+++ b/src/lib/clapper/clapper-utils.c
@@ -287,7 +287,7 @@ clapper_utils_title_from_uri (const gchar *uri)
 }
 
 gboolean
-clapper_utils_set_value_from_variant (GValue *value, GVariant *variant)
+clapper_utils_set_value_for_enhancer (GValue *value, GParamSpec *pspec, GSettings *settings, GVariant *variant)
 {
   const gchar *var_type = g_variant_get_type_string (variant);
   GType val_type;
@@ -306,7 +306,10 @@ clapper_utils_set_value_from_variant (GValue *value, GVariant *variant)
       val_type = G_TYPE_DOUBLE;
       break;
     case 's':
-      val_type = G_TYPE_STRING;
+      if (G_IS_PARAM_SPEC_ENUM (pspec) || G_IS_PARAM_SPEC_FLAGS (pspec))
+        val_type = pspec->value_type;
+      else
+        val_type = G_TYPE_STRING;
       break;
     default:
       goto error;
@@ -331,7 +334,12 @@ clapper_utils_set_value_from_variant (GValue *value, GVariant *variant)
       g_value_set_string (value, g_variant_get_string (variant, NULL));
       break;
     default:
-      g_assert_not_reached ();
+      if (G_IS_PARAM_SPEC_ENUM (pspec))
+        g_value_set_enum (value, g_settings_get_enum (settings, pspec->name));
+      else if (G_IS_PARAM_SPEC_FLAGS (pspec))
+        g_value_set_flags (value, g_settings_get_flags (settings, pspec->name));
+      else
+        g_assert_not_reached ();
       break;
   }
 


### PR DESCRIPTION
Enums and flags are stored as strings in GSettings, but they should be parsed back into correct GTypes before using them.

This commit includes needed changes to internal Clapper functions so such settings are handled correctly when converting them to/from GValue using GSettings dedicated getters for enums/flags that parse value to correct type.